### PR TITLE
Add in-app remote pCUE control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,6 @@ Most critical facts (full detail in `CLAUDE.md`):
 - **Do not upgrade LibreHardwareMonitorLib past 0.9.4** or **HidSharp past 2.1.0** — both break the
   Commander PRO HID code. (CPU Temp/MHz/Load come from LibreHardwareMonitor.)
 - **AssemblyVersion stays 1.1.0.0; AssemblyFileVersion auto-bumps on every _Release_ build** (inline
-  MSBuild task) — don't hand-edit it. C# 7.3 (no nullable-reference annotations).
+  MSBuild task) — don't hand-edit it. C# 12 on .NET Framework 4.8 (no nullable-reference annotations).
 - Fan numeric box: **≤100 = PWM power %** (whole-percent only, hardware limit), **>100 = fixed RPM**.
 - External bench tachometer (VID 0x1A86/PID 0xE008) support lives in `pCUE/Tachometer/HidTachometer.cs`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ current. `AGENTS.md` is a thin pointer to this file.
 ## What it does
 Reads the Commander PRO over USB-HID and shows per-fan RPM (Current/Min/Max/Avg) plus CPU
 Temp/MHz/Load; lets the user set fan mode (Auto / 3-pin / 4-pin / Disconnect), fan speed
-(PWM % or fixed RPM), sync all fans, and auto-start with Windows. Requires admin (manifest
+(PWM % or fixed RPM), sync all fans, and auto-start with Windows. The same window can target local
+hardware or another pCUE PC and mirror/control it live. Requires admin (manifest
 `requireAdministrator`) so LibreHardwareMonitor can load its kernel driver.
 
 ## Key files (all under `pCUE/`)
@@ -20,7 +21,13 @@ Temp/MHz/Load; lets the user set fan mode (Auto / 3-pin / 4-pin / Disconnect), f
   `_lastCommandedDuty` tracking (only updated on ACCEPTED writes).
 - `CorsairLightingProtocolConstants.cs` — Commander PRO HID command bytes.
 - `Tachometer/HidTachometer.cs` — external bench tachometer driver (see session log).
+- `Remote/PcueRemoteModels.cs` — protocol-v2 typed status/action/discovery contract.
+- `Remote/PcueRemoteClient.cs` — embedded HTTP/SSE client, command serialization, discovery, and
+  automatic reconnect. It is part of pCUE; the PowerShell CLI is not a GUI dependency.
+- `Remote/RemoteControlServer.cs` — authenticated local/LAN control API used by another pCUE and
+  the optional CLI.
 - `Properties/AssemblyInfo.cs` — versions.
+- `tests/RemoteProtocolTests/` (at repo root) — dependency-free net48 loopback integration suite.
 
 ## How the numeric fan box works (important)
 One `UIntegerUpDown` per fan does double duty: on **Set Speed**, value **≤ 100 → PWM power %**
@@ -144,13 +151,27 @@ is how Windows recognises an in-place upgrade. `PrivilegesRequired=admin` (the a
 `CloseApplications=yes` so an update can replace a running `pCUE.exe`, and the HKCU `Run` value is
 removed on **uninstall only** so an in-place update keeps the user's Auto Start choice.
 
-## Remote control + debug logging
-Modelled on Powenetics V3's `RemoteControlServer`, so the two apps behave the same way. **Off unless
-asked for on the command line** — nothing is persisted and no token is ever written to disk.
+## In-app remote pCUE + debug logging
+The main window's **Target** strip selects **This PC** or **Remote**. Remote uses the same fan,
+Commander, CPU, tachometer, settings and Reset/Kill buttons; incoming typed snapshots update the
+existing controls, and edits are sent back through the embedded client. It consumes a continuous
+SSE status stream at 500 ms and reconnects with bounded 1/2/5/10-second backoff after a network
+loss. Host/port persist; the **client token is memory-only** and is sent only in `X-pCUE-Token`.
+
+The remote instance must run protocol v2 (`status.protocolVersion >= 2`, first shipped in 1.5.5).
+Older pCUE versions are rejected with a clear update message rather than producing a half-working
+UI. In client mode this instance temporarily stops its own API/beacon so it cannot proxy a request
+to a third PC. Its local Commander/tach session keeps running; local UI state and monitoring are
+restored when Target returns to This PC.
+
+On the target, **Allow remote** starts the `RemoteControlServer` and passive discovery beacon. The
+server setting, port and server token are user-scoped settings and persist. An empty server token
+binds to loopback only; a non-empty token is what enables the LAN prefix. Command-line flags remain
+available for one-off/automation launches:
 
 ```
-pCUE.exe --remote --debug                                                  # loopback only
-pCUE.exe --remote-prefix=http://+:5056/ --remote-token=SECRET --debug      # LAN
+pCUE.exe --remote --debug                              # loopback, saved/default port
+pCUE.exe --remote-port=5056 --remote-token=SECRET      # LAN, token required
 ```
 
 - `--debug` sets the log to **Debug** and mirrors it to
@@ -160,16 +181,23 @@ pCUE.exe --remote-prefix=http://+:5056/ --remote-token=SECRET --debug      # LAN
   goes in `X-pCUE-Token` or `?token=`. Binding a non-loopback prefix needs elevation (pCUE already
   runs elevated) and a firewall rule for TCP 5056 / UDP 5057.
 - **Discovery** (`Remote/DiscoveryBeacon.cs`): a *passive* UDP responder on 5057 — it answers a
-  `PCUE_DISCOVER` probe with app/version/host/url/requiresToken and is otherwise silent. It never
-  returns the token.
+  `PCUE_DISCOVER` probe with app/protocolVersion/version/host/url/requiresToken and is otherwise
+  silent. It never returns the token.
 - **CLI:** `tools/pcue-cli.ps1` reaches **every** endpoint; `tools/pcue.cmd` is a shim so it reads
   as `pcue status`. `pcue commands` prints the lot. Host and token come from `PCUE_SERVER` /
-  `PCUE_TOKEN` so they are not retyped — and the token is **never written to disk**, matching the
-  app. With no server named it tries loopback, then LAN discovery. `-Json` on anything for raw
-  output. **Exit codes are load-bearing** — `0` ok, `1` pCUE refused, `2` nothing reachable,
-  `3` bad usage — so a bench script can tell "the app said no" from "the app was not there".
-  The old spellings (`debug`, `cpu-start/stop`, `tach-connect/disconnect`) are kept as aliases.
+  `PCUE_TOKEN`, so the CLI token is never written to disk. With no server named it tries loopback,
+  then LAN discovery. `apply` sends all six GUI setpoints atomically; `average`, `autostart`,
+  `autoconnect`, `tach-adjust`, and `kill-icue` cover the new GUI parity endpoints. `-Json` on
+  anything for raw output. **Exit codes are load-bearing** — `0` ok, `1` pCUE refused, `2` nothing
+  reachable, `3` bad usage — so a bench script can tell "the app said no" from "the app was not
+  there". The old spellings (`debug`, `cpu-start/stop`, `tach-connect/disconnect`) remain aliases.
   `GET /` lists every endpoint at runtime.
+
+### Protocol-v2 validation
+`scripts/Invoke-LocalCI.ps1` now builds/runs `tests/RemoteProtocolTests`: correct-token and
+wrong-token paths, typed status and SSE snapshots, all GUI-parity routes, six-setpoint JSON body,
+stream loss plus automatic reconnect, manual disconnect, and rejection of protocol v1. The same
+pipeline parses the CLI, renders/measures both WPF windows, and packages the installer.
 
 ### Logging (`pCUE/Diagnostics/AppLog.cs`) — read this before adding diagnostics
 The rest of the app logs through `Debug.WriteLine`, which is `[Conditional("DEBUG")]` and therefore
@@ -305,7 +333,33 @@ fail = attach `B_phase*.json` timelines). If A SKIPs because no channel is 3-pin
   RPM target only works if the Commander can read that fan's sense wire.
 
 ## Session log (newest first)
-### 2026-08-25 (latest) — The status-byte check was reading the report id, so it never fired
+### 2026-08-28 — In-app remote pCUE completed; 1.5.5 package built
+- Added the Target strip and the embedded `PcueRemoteClient`: a local pCUE can now select Remote,
+  discover/enter another pCUE, connect with a memory-only token, receive live CPU/fan/tach/hold
+  readings in the normal controls, and drive the full existing interface. No browser, PowerShell,
+  or companion GUI is involved. The client reconnects automatically and rejects old protocol
+  versions cleanly.
+- Promoted `/status` to the typed protocol-v2 contract and added atomic `/fans/apply`, remote UI
+  settings, and `/system/kill-icue`. Discovery advertises the protocol version. The CLI gained
+  matching commands.
+- Target switching stops the local API to prevent proxy chains but preserves the local Commander,
+  tachometer, fan polling, hold and UI choices; only local CPU polling pauses while remote readings
+  own the screen, then resumes if it was running.
+- Added the net48 loopback integration project and made it a local-CI gate. Verified: wrong-token
+  rejection, status/SSE, every new route, server loss/restart/reconnect, protocol-v1 rejection,
+  CLI parse, and WPF layout (**18 Help controls + 116 Main controls, zero overlaps**). The full
+  pipeline passed with only the four pre-existing HidSharp obsolete warnings.
+- Built the required unsigned **1.5.5** artifacts from a clean Release stage: installer
+  `pCUE_1.5.5_setup.exe` (2,616,944 bytes), SHA-256
+  `525392D64FF54DDC1A22D49C91646FE08CB49E81BFC8A6E3BA764BFC62A38B05`; portable zip 652,501
+  bytes, SHA-256 `6A74D9D382A4E36897205DF5E8861B3E57760ED11C5EDD8A78E8089602D8A2A2`.
+- Hardware check before implementation: on the remote Sound-PC, Fan #2 showed 0 RPM and did not
+  start at 100% in either 3-pin/DC or 4-pin/PWM mode. Its original 3-pin, 40%, Sync state was
+  restored. With the connector confirmed seated by the owner, that result points outside the
+  percentage/mode UI path (fan, power/contact, channel, or wiring still needs physical isolation).
+  The bench still ran 1.5.4, so cross-PC GUI validation requires updating both ends to 1.5.5.
+
+### 2026-08-25 — The status-byte check was reading the report id, so it never fired
 Verifying the 1.5.3 work found that **enforcing the status byte was inert**. `LogExchange` read
 `_in[0]`, which is the HID **report id** — always `0x00`, and `PROTOCOL_RESPONSE_OK` is `0x00`, so
 `ok` was unconditionally true. Consequences, all of them silent: `WriteFan*` always returned true,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ to drive and a fraction of the size.
 - Live CPU temperature, clock and load (via LibreHardwareMonitor)
 - Min / Max / Average per fan and for the CPU
 - Closed-loop **RPM hold** using an external bench tachometer
-- In-app updates, and an optional HTTP remote-control API
+- In-app updates, an optional HTTP remote-control API, and full in-app control of another pCUE PC
 
 Requires Windows and .NET Framework 4.8 (shipped with Windows 10 1903+ and Windows 11). pCUE runs
 elevated, because reading CPU sensors needs it.
@@ -44,7 +44,20 @@ which is enough to adapt the decoder.
 
 ## Remote control (optional)
 
-Tick **Remote** to expose an HTTP API for scripting or unattended benches.
+Use the new **Target** strip to work on another PC without leaving pCUE:
+
+1. On the bench PC, tick **Allow remote**, choose a token, and leave pCUE running.
+2. On your control PC, choose **Remote pCUE**, enter the bench name/IP and the same token, then
+   press **Connect**. **Find** can locate a pCUE instance on the LAN.
+3. The normal pCUE interface now shows the remote CPU, fans, tachometer and hold state. Its existing
+   buttons, fan modes, sliders and settings operate the remote PC. Switch Target back to **This PC**
+   to restore the local state.
+
+The connection uses a live status stream and reconnects automatically after a brief network loss.
+The client remembers the host and port, but deliberately keeps its token in memory only.
+
+Tick **Allow remote** to expose the local pCUE API for another pCUE, scripting, or an unattended
+bench.
 
 - With the **Token** box empty, pCUE listens on `127.0.0.1` only.
 - Entering a token is what allows access from other machines, and every such request must present
@@ -77,9 +90,9 @@ $env:PCUE_SERVER = '192.168.1.20'
 $env:PCUE_TOKEN  = 'the-token-you-typed-in-the-app'
 ```
 
-The token is read from the environment and **never written to disk**, matching the app, which does
-not persist it either. With no `-Server` and no `PCUE_SERVER`, the CLI tries localhost and then
-asks the LAN who is listening — `pcue discover` on its own lists what it finds.
+The CLI token is read from the environment and **never written to disk**, matching the in-app
+remote client. With no `-Server` and no `PCUE_SERVER`, the CLI tries localhost and then asks the
+LAN who is listening — `pcue discover` on its own lists what it finds.
 
 Add `-Json` to any command for raw output. Exit codes are meaningful, so a bench script can tell
 the cases apart: `0` success, `1` pCUE refused the request, `2` no pCUE reachable, `3` bad usage.
@@ -88,7 +101,7 @@ the cases apart: `0` success, `1` pCUE refused the request, `2` no pCUE reachabl
 
 ```powershell
 MSBuild pCUE\pCUE.csproj /p:Configuration=Debug
-pwsh scripts\Invoke-LocalCI.ps1     # build + UI layout check + packaging
+pwsh scripts\Invoke-LocalCI.ps1     # build + remote integration + UI layout + packaging
 pwsh build\pack-release.ps1         # installer + portable zip into artifacts\
 ```
 

--- a/pCUE.sln
+++ b/pCUE.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.31313.79
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "pCUE", "pCUE\pCUE.csproj", "{BE3BB717-C408-4BF4-8C92-582D88219788}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteProtocolTests", "tests\RemoteProtocolTests\RemoteProtocolTests.csproj", "{637B0C9A-2584-45D9-83E3-35ADBD96EA22}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{BE3BB717-C408-4BF4-8C92-582D88219788}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE3BB717-C408-4BF4-8C92-582D88219788}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE3BB717-C408-4BF4-8C92-582D88219788}.Release|Any CPU.Build.0 = Release|Any CPU
+		{637B0C9A-2584-45D9-83E3-35ADBD96EA22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{637B0C9A-2584-45D9-83E3-35ADBD96EA22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{637B0C9A-2584-45D9-83E3-35ADBD96EA22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{637B0C9A-2584-45D9-83E3-35ADBD96EA22}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/pCUE/HelpWindow.xaml
+++ b/pCUE/HelpWindow.xaml
@@ -126,9 +126,15 @@
                     <Bold>Check for Updates</Bold> looks for a newer pCUE. It verifies the download's
                     checksum and always asks before installing; <Bold>On start</Bold> only checks, it never
                     installs on its own.
-                    <LineBreak/><Bold>Remote</Bold> lets pCUE be driven over HTTP. With the
-                    <Bold> Token</Bold> box empty it listens on this PC only; entering a token is what allows
-                    access from other machines, and every such request must then present it.
+                    <LineBreak/><Bold>Target</Bold> chooses whether this window controls <Bold>This PC</Bold>
+                    or another <Bold>Remote pCUE</Bold>. For a remote target, enter its PC name or IP,
+                    port and token, then press <Bold>Connect</Bold>; <Bold>Find</Bold> searches the LAN.
+                    The same fan, Commander, CPU and tachometer controls then operate that PC, and all
+                    readings shown here are its live readings. The host and port are remembered, but
+                    the client token is kept in memory only.
+                    <LineBreak/><Bold>Allow remote</Bold> lets another pCUE or the CLI control this PC.
+                    With the <Bold> Token</Bold> box empty it listens on this PC only; entering a token is
+                    what allows access from other machines, and every such request must then present it.
                     <Bold> Debug log</Bold> records detailed diagnostics to
                     %LOCALAPPDATA%\pCUE\logs, which is what to send if something misbehaves.
                 </TextBlock>

--- a/pCUE/MainWindow.xaml
+++ b/pCUE/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:system="clr-namespace:System;assembly=mscorlib"
         xmlns:wf="clr-namespace:System.Windows.Forms;assembly=System.Windows.Forms"      
     
-    Title="pCUE - Cybenetics LTD" Height="630" Width="626" Foreground="#FFE0E5C8" ResizeMode="CanMinimize" Loaded="Window_Loaded" Closed="Window_Closed" Closing="Window_Closing" Icon="small.ico">
+    Title="pCUE - Cybenetics LTD" Height="687" Width="626" Foreground="#FFE0E5C8" ResizeMode="CanMinimize" Loaded="Window_Loaded" Closed="Window_Closed" Closing="Window_Closing" Icon="small.ico">
 
     <Window.Background>
         <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
@@ -23,7 +23,7 @@
         </x:ArrayExtension>
     </Window.Resources>
 
-    <Grid x:Name="Main_Window" Margin="0,0,3.4,0" Height="597" VerticalAlignment="Top">
+    <Grid x:Name="Main_Window" Margin="0,0,3.4,0" Height="654" VerticalAlignment="Top">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="51*"/>
             <ColumnDefinition Width="86*"/>
@@ -166,13 +166,28 @@
         <CheckBox x:Name="Update_On_Start_CheckBox" Content="On start" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="153,529,0,0" Foreground="#FFF5EFEF" ToolTip="Check for a newer pCUE version when the app starts (checks only - never installs on its own)" Checked="Update_On_Start_Changed" Unchecked="Update_On_Start_Changed"/>
         <TextBlock x:Name="Update_Status_Label" Grid.ColumnSpan="2" Text="" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="225,529,0,0" Width="379" Height="20" TextTrimming="CharacterEllipsis" FontWeight="Bold" Foreground="White"/>
 
-        <Label Content="Remote:" Style="{StaticResource White_Labels}" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="16,556,0,0" Height="25"/>
-        <CheckBox x:Name="Remote_Enable_CheckBox" Content="Enable" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="76,561,0,0" Foreground="#FFF5EFEF" ToolTip="Allow pCUE to be controlled over HTTP. Without a token it listens on this PC only; set a token to allow access from the network." Checked="Remote_Settings_Changed" Unchecked="Remote_Settings_Changed"/>
-        <Label Content="Port:" Style="{StaticResource White_Labels}" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="140,556,0,0" Height="25"/>
-        <TextBox x:Name="Remote_Port_Box" Grid.ColumnSpan="2" Text="5056" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="178,559,0,0" Width="46" Height="21" Background="#FF15743E" Foreground="#FFF6F1F1" HorizontalContentAlignment="Center" LostFocus="Remote_Settings_Changed"/>
-        <Label Content="Token:" Style="{StaticResource White_Labels}" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="230,556,0,0" Height="25"/>
-        <PasswordBox x:Name="Remote_Token_Box" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="280,559,0,0" Width="104" Height="21" Background="#FF15743E" Foreground="#FFF6F1F1" ToolTip="Required for access from other machines. Leave empty to keep pCUE reachable only from this PC." LostFocus="Remote_Settings_Changed"/>
-        <CheckBox x:Name="Debug_Log_CheckBox" Content="Debug log" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="394,561,0,0" Foreground="#FFF5EFEF" ToolTip="Verbose logging to %LOCALAPPDATA%\pCUE\logs (and readable over the remote API)" Checked="Debug_Log_Changed" Unchecked="Debug_Log_Changed"/>
-        <TextBlock x:Name="Remote_Status_Label" Grid.ColumnSpan="2" Text="● Off" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="482,562,0,0" Width="122" Height="20" TextTrimming="CharacterEllipsis" FontWeight="Bold" Foreground="#FFD3D3D3"/>
+        <Label Content="Target:" Style="{StaticResource White_Labels}" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="16,556,0,0" Height="25"/>
+        <ComboBox x:Name="Target_Mode_Combo" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="68,559,0,0" Width="78" Height="22" SelectionChanged="Target_Mode_SelectionChanged" ToolTip="Control hardware on this PC, or use this same interface to control another pCUE instance.">
+            <ComboBoxItem Content="This PC" IsSelected="True"/>
+            <ComboBoxItem Content="Remote"/>
+        </ComboBox>
+        <Label Content="Host:" Style="{StaticResource White_Labels}" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="152,556,0,0" Height="25"/>
+        <TextBox x:Name="Remote_Client_Host_Box" Grid.ColumnSpan="2" Text="" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="192,559,0,0" Width="110" Height="21" Background="#FF15743E" Foreground="#FFF6F1F1" ToolTip="Remote PC name, IP address, or pCUE base URL." LostFocus="Remote_Client_Settings_Changed"/>
+        <Label Content="Port:" Style="{StaticResource White_Labels}" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="307,556,0,0" Height="25"/>
+        <TextBox x:Name="Remote_Client_Port_Box" Grid.ColumnSpan="2" Text="5056" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="345,559,0,0" Width="46" Height="21" Background="#FF15743E" Foreground="#FFF6F1F1" HorizontalContentAlignment="Center" LostFocus="Remote_Client_Settings_Changed"/>
+        <Label Content="Token:" Style="{StaticResource White_Labels}" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="396,556,0,0" Height="25"/>
+        <PasswordBox x:Name="Remote_Client_Token_Box" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="444,559,0,0" Width="93" Height="21" Background="#FF15743E" Foreground="#FFF6F1F1" ToolTip="Held in memory only and sent in the X-pCUE-Token header."/>
+        <Button x:Name="Remote_Client_Connect_Button" Content="Connect" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="544,557,0,0" Width="60" Height="24" Background="#FF3806FB" Foreground="#FFFBF5F5" Click="Remote_Client_Connect_Click"/>
+        <TextBlock x:Name="Remote_Client_Status_Label" Grid.ColumnSpan="2" Text="● This PC" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="16,586,0,0" Width="520" Height="20" TextTrimming="CharacterEllipsis" FontWeight="Bold" Foreground="White"/>
+        <Button x:Name="Remote_Client_Discover_Button" Content="Find" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="544,583,0,0" Width="60" Height="24" Background="#FF3806FB" Foreground="#FFFBF5F5" Click="Remote_Client_Discover_Click" ToolTip="Find a pCUE instance on the local network."/>
+
+        <Label Content="Allow remote:" Style="{StaticResource White_Labels}" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="16,614,0,0" Height="25"/>
+        <CheckBox x:Name="Remote_Enable_CheckBox" Content="Enable" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="105,619,0,0" Foreground="#FFF5EFEF" ToolTip="Allow this pCUE to be controlled over HTTP. Without a token it listens on this PC only; set a token to allow access from the network." Checked="Remote_Settings_Changed" Unchecked="Remote_Settings_Changed"/>
+        <Label Content="Port:" Style="{StaticResource White_Labels}" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="169,614,0,0" Height="25"/>
+        <TextBox x:Name="Remote_Port_Box" Grid.ColumnSpan="2" Text="5056" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="207,617,0,0" Width="46" Height="21" Background="#FF15743E" Foreground="#FFF6F1F1" HorizontalContentAlignment="Center" LostFocus="Remote_Settings_Changed"/>
+        <Label Content="Token:" Style="{StaticResource White_Labels}" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="258,614,0,0" Height="25"/>
+        <PasswordBox x:Name="Remote_Token_Box" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="306,617,0,0" Width="104" Height="21" Background="#FF15743E" Foreground="#FFF6F1F1" ToolTip="Required for access from other machines. Leave empty to keep pCUE reachable only from this PC." LostFocus="Remote_Settings_Changed"/>
+        <CheckBox x:Name="Debug_Log_CheckBox" Content="Local debug" Grid.ColumnSpan="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="419,619,0,0" Foreground="#FFF5EFEF" ToolTip="Verbose logging for this pCUE to %LOCALAPPDATA%\pCUE\logs." Checked="Debug_Log_Changed" Unchecked="Debug_Log_Changed"/>
+        <TextBlock x:Name="Remote_Status_Label" Grid.ColumnSpan="2" Text="● Off" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="510,620,0,0" Width="94" Height="20" TextTrimming="CharacterEllipsis" FontWeight="Bold" Foreground="#FFD3D3D3"/>
     </Grid>
 </Window>

--- a/pCUE/MainWindow.xaml.cs
+++ b/pCUE/MainWindow.xaml.cs
@@ -75,6 +75,9 @@ namespace pCUE
         //Series indices inside the stats bank.
         const int StatCpuTemp = 0, StatCpuClock = 1, StatCpuLoad = 2;
         const int StatFanBase = 3;   // fans 0..5 -> StatFanBase+0..+5
+        double latestCpuTemperature;
+        double latestCpuClock;
+        double latestCpuLoad;
 
         //Control arrays. Built explicitly from the named fields in the constructor - the old
         //FindLogicalChildren walk depended on XAML declaration order, so reordering the XAML
@@ -120,6 +123,34 @@ namespace pCUE
         //Optional HTTP remote-control server. Off unless enabled on the command line.
         RemoteControlServer remoteServer;
         DiscoveryBeacon discoveryBeacon;
+
+        //The same window can target local hardware or another pCUE instance. The client is pure
+        //C# inside pCUE; the PowerShell CLI remains an optional operator tool, never a dependency.
+        readonly PcueRemoteClient remoteClient;
+        PcueStatusSnapshot lastRemoteSnapshot;
+        readonly bool[] remoteSetpointDirty = new bool[6];
+        bool remoteSnapshotApplying;
+        string localWindowTitle = "pCUE - Cybenetics LTD";
+        readonly int[] savedLocalModes = new int[6];
+        readonly uint[] savedLocalSetpoints = new uint[6];
+        bool savedLocalSync;
+        bool savedLocalAverage;
+        bool savedLocalAutoStart;
+        bool savedLocalAutoConnect;
+        bool savedLocalTachoAdjust;
+        bool savedLocalCommanderConnected;
+        bool savedLocalCpuMonitoring;
+        bool savedLocalTachConnected;
+        bool savedLocalRemoteEnabled;
+        string savedLocalCommanderFirmware;
+        string savedLocalHoldDisplay;
+        int savedLocalTachAssignment;
+        bool localUiStateSaved;
+
+        bool IsRemoteMode
+        {
+            get { return Target_Mode_Combo != null && Target_Mode_Combo.SelectedIndex == 1; }
+        }
 
         //In-app updater (checks a signed-manifest URL; never installs on its own).
         AppUpdateService updateService;
@@ -167,6 +198,10 @@ namespace pCUE
             //the panel and the fan column agree on what "fresh" means.
 
             updateService = new AppUpdateService();
+
+            remoteClient = new PcueRemoteClient();
+            remoteClient.SnapshotReceived += RemoteClient_SnapshotReceived;
+            remoteClient.ConnectionChanged += RemoteClient_ConnectionChanged;
         }
 
         #region Main Window Functions
@@ -180,6 +215,7 @@ namespace pCUE
                     .GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location)
                     .FileVersion;
                 this.Title = "pCUE - Cybenetics LTD - v." + fileVersion;
+                localWindowTitle = this.Title;
             }
             catch (Exception ex) { Debug.WriteLine("pCUE: could not read file version: " + ex.Message); }
 
@@ -190,6 +226,11 @@ namespace pCUE
             { AVG_values.IsChecked = true; }
 
             StartRemoteControlIfRequested();
+
+            Remote_Client_Host_Box.Text = Properties.Settings.Default.Remote_Client_Host ?? "";
+            Remote_Client_Port_Box.Text = Properties.Settings.Default.Remote_Client_Port.ToString();
+            Target_Mode_Combo.SelectedIndex = 0;   //always start safe: local control is explicit
+            ApplyTargetModeUi();
 
             //Opt-in auto-connect. Deliberately NOT the default: opening the Commander also kills
             //the iCUE services, which would be a rude thing to do unasked on every launch. It earns
@@ -253,6 +294,9 @@ namespace pCUE
 
             try { discoveryBeacon?.Dispose(); }
             catch (Exception ex) { Debug.WriteLine("pCUE: discovery beacon dispose failed: " + ex.Message); }
+
+            try { remoteClient?.Dispose(); }
+            catch (Exception ex) { Debug.WriteLine("pCUE: remote client dispose failed: " + ex.Message); }
         }
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
@@ -281,7 +325,7 @@ namespace pCUE
         {
             //The Min/Max/Avg figures are now maintained where each value is produced; this timer
             //only keeps the bench-tachometer readout honest about stale/lost signal.
-            Update_Tach_Panel();
+            if (!IsRemoteMode) Update_Tach_Panel();
         }
 
         //Shows the running average of each fan in its own column (ed28..ed33)
@@ -433,10 +477,13 @@ namespace pCUE
             {
                 int idx = ch * 3;                     // channel -> "Current" index in Fan_array (0,3,6,9,12,15)
                 if (idx >= Fan_array.Length) return;
-                Fan_array[idx].Text = rpms[ch].ToString();
                 stats.Add(StatFanBase + ch, rpms[ch]);
+                if (!IsRemoteMode) Fan_array[idx].Text = rpms[ch].ToString();
             }
 
+            //Keep collecting the local session while another pCUE is on screen, but never let its
+            //poller overwrite the remote readouts. Switching back reveals the accumulated values.
+            if (IsRemoteMode) return;
             Set_Fan_Average_Column();
             RenderFanMinMaxColumns();
         }
@@ -450,6 +497,8 @@ namespace pCUE
             Corsair_Commander_Connected = false;
             StopFanPolling();   //cancellation only - never waits on the poll task
             commander.Disconnect();   //nulls + closes the stream, interrupting any blocked read
+
+            if (IsRemoteMode) return; //the remote target owns the visible controls for now
 
             //reset the UI to the disconnected state
             Open_Corsair_Commander.Content = "Open";
@@ -498,8 +547,27 @@ namespace pCUE
         //to ITS caller too (the write itself happens inside the SelectionChanged event).
         readonly bool[] fanModeWriteOk = new bool[6];
 
-        private void Commander_Pro_Set_Fan_Connection_Mode(object sender, SelectionChangedEventArgs e)
+        private async void Commander_Pro_Set_Fan_Connection_Mode(object sender, SelectionChangedEventArgs e)
         {
+            if (remoteSnapshotApplying) return;
+
+            if (IsRemoteMode)
+            {
+                int remoteFan = Array.IndexOf(Fan_Mode_Controls, sender as ComboBox);
+                if (remoteFan < 0) return;
+                if (!remoteClient.IsConnected)
+                {
+                    SetRemoteClientError("Remote pCUE is not connected.");
+                    return;
+                }
+                string[] modes = { "auto", "3pin", "4pin", "disconnect" };
+                int selected = Fan_Mode_Controls[remoteFan].SelectedIndex;
+                if (selected < 0 || selected >= modes.Length) return;
+                ShowRemoteActionResult(await remoteClient.SetFanModeAsync(remoteFan + 1, modes[selected]),
+                                       "Fan " + (remoteFan + 1) + " mode accepted");
+                return;
+            }
+
             if (Corsair_Commander_Connected != true) return;
 
             String nam = ((ComboBox)sender).Name;
@@ -546,8 +614,17 @@ namespace pCUE
             return commander.WriteFanPower(fan_channel, fan_power);
         }
 
-        private void Open_Corsair_Commander_Click(object sender, RoutedEventArgs e)
+        private async void Open_Corsair_Commander_Click(object sender, RoutedEventArgs e)
         {
+            if (IsRemoteMode)
+            {
+                if (!remoteClient.IsConnected) { SetRemoteClientError("Remote pCUE is not connected."); return; }
+                bool open = Open_Corsair_Commander.Content.ToString() == "Open";
+                ShowRemoteActionResult(await remoteClient.SetCommanderOpenAsync(open),
+                                       open ? "Remote Commander opened" : "Remote Commander closed");
+                return;
+            }
+
              if (Open_Corsair_Commander.Content.ToString() == "Open")
             {
                 try
@@ -673,6 +750,10 @@ namespace pCUE
                 double clock = coreAvgClk ?? (clockCount > 0 ? clockSum / clockCount : 0.0);
                 double load = totalLoad ?? 0.0;
 
+                latestCpuTemperature = temperature;
+                latestCpuClock = clock;
+                latestCpuLoad = load;
+
                 CPU_array[0].Text = temperature.ToString("0.0");
                 CPU_array[3].Text = clock.ToString("N1");
                 CPU_array[6].Text = load.ToString("N1");
@@ -691,8 +772,14 @@ namespace pCUE
         #endregion
 
         #region App Kill functions
-        private void Kill_iCUE_services_Click(object sender, RoutedEventArgs e)
+        private async void Kill_iCUE_services_Click(object sender, RoutedEventArgs e)
         {
+            if (IsRemoteMode)
+            {
+                if (!remoteClient.IsConnected) { SetRemoteClientError("Remote pCUE is not connected."); return; }
+                ShowRemoteActionResult(await remoteClient.KillIcueAsync(), "Remote iCUE services stopped");
+                return;
+            }
             Kill_iCUE_Function();
         }
 
@@ -853,6 +940,14 @@ namespace pCUE
 
         private void Fan_Numeric_ValueChanged(object sender, RoutedPropertyChangedEventArgs<uint> e)
         {
+            int changed = Array.IndexOf(Fan_Numeric_Boxes, sender as NumericUpDownLib.UIntegerUpDown);
+            if (remoteSnapshotApplying)
+            {
+                if (changed >= 0) Fan_Slider[changed].Value = Fan_Numeric_Boxes[changed].Value;
+                return;
+            }
+            if (IsRemoteMode && changed >= 0) remoteSetpointDirty[changed] = true;
+
             if (Sync_Fans_CheckBox.IsChecked == true)
             {
                 Fan1_Slider.Value = Decimal.ToInt32(Fan1_Numeric.Value);
@@ -875,6 +970,14 @@ namespace pCUE
 
         private void Fan_Slider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
+            int changed = Array.IndexOf(Fan_Slider, sender as Slider);
+            if (remoteSnapshotApplying)
+            {
+                if (changed >= 0) Fan_Numeric_Boxes[changed].Value = Convert.ToUInt32(Fan_Slider[changed].Value);
+                return;
+            }
+            if (IsRemoteMode && changed >= 0) remoteSetpointDirty[changed] = true;
+
             if (Sync_Fans_CheckBox.IsChecked == true)
             {
                 Fan1_Numeric.Value = Convert.ToUInt32(Fan1_Slider.Value);
@@ -896,8 +999,18 @@ namespace pCUE
         }
 
         //for the Average Values CheckBox
-        private void Average_Values(object sender, RoutedEventArgs e)
+        private async void Average_Values(object sender, RoutedEventArgs e)
         {
+            if (remoteSnapshotApplying) return;
+            if (IsRemoteMode)
+            {
+                if (!remoteClient.IsConnected) { SetRemoteClientError("Remote pCUE is not connected."); return; }
+                bool remoteAverage = AVG_values.IsChecked == true;
+                CPU_box.Header = remoteAverage ? "CPU Current/AVG/Max" : "CPU Current/Min/Max";
+                ShowRemoteActionResult(await remoteClient.SetAverageValuesAsync(remoteAverage));
+                return;
+            }
+
             if (AVG_values.IsChecked == true)
             {
                 CPU_box.Header = "CPU Current/AVG/Max";
@@ -913,8 +1026,14 @@ namespace pCUE
             RenderCpuMinMaxColumns();   //swap the middle column immediately, not on the next sample
         }
 
-        private void Reset_Button_Click(object sender, RoutedEventArgs e)
+        private async void Reset_Button_Click(object sender, RoutedEventArgs e)
         {
+            if (IsRemoteMode)
+            {
+                if (!remoteClient.IsConnected) { SetRemoteClientError("Remote pCUE is not connected."); return; }
+                ShowRemoteActionResult(await remoteClient.ResetStatsAsync(), "Remote statistics reset");
+                return;
+            }
             Reset_function();
         }
 
@@ -937,8 +1056,19 @@ namespace pCUE
             Set_Fan_Average_Column();   //the Avg column is not part of Fan_array - clear it too
         }
 
-        private void Set_Fan_Speed_Click(object sender, RoutedEventArgs e)
+        private async void Set_Fan_Speed_Click(object sender, RoutedEventArgs e)
         {
+            if (IsRemoteMode)
+            {
+                if (!remoteClient.IsConnected) { SetRemoteClientError("Remote pCUE is not connected."); return; }
+                int[] setpoints = Fan_Numeric_Boxes.Select(box => (int)box.Value).ToArray();
+                PcueApiActionResponse response = await remoteClient.ApplyFanSetpointsAsync(setpoints);
+                if (response != null && response.ok)
+                    Array.Clear(remoteSetpointDirty, 0, remoteSetpointDirty.Length);
+                ShowRemoteActionResult(response, "Remote fan setpoints accepted");
+                return;
+            }
+
             //Checked here, not per-fan: the wrappers' false means "the DEVICE refused", and a
             //pre-connect click would otherwise report all six fans as rejected.
             if (!Corsair_Commander_Connected)
@@ -1022,11 +1152,11 @@ namespace pCUE
             return true;
         }
 
-        public object GetStatus()
+        public PcueStatusSnapshot GetStatus()
         {
-            return Dispatcher.Invoke(new Func<object>(delegate
+            return Dispatcher.Invoke(new Func<PcueStatusSnapshot>(delegate
             {
-                var fans = new List<object>();
+                var fans = new List<PcueFanStatus>();
                 for (int ch = 0; ch < 6; ch++)
                 {
                     int rpm;
@@ -1044,12 +1174,15 @@ namespace pCUE
                         }
                     }
 
-                    fans.Add(new
+                    fans.Add(new PcueFanStatus
                     {
                         fan = ch + 1,
-                        rpm,
-                        mode,
+                        rpm = rpm,
+                        mode = mode,
                         setpoint = ch < Fan_Numeric_Boxes.Length ? (int)Fan_Numeric_Boxes[ch].Value : 0,
+                        min = stats.Min(StatFanBase + ch),
+                        max = stats.Max(StatFanBase + ch),
+                        average = stats.Average(StatFanBase + ch),
                     });
                 }
 
@@ -1074,39 +1207,70 @@ namespace pCUE
                     dutySource = tracked >= 0 ? "tracked" : "unknown";
                 }
 
-                return new
+                return new PcueStatusSnapshot
                 {
                     app = "pCUE",
+                    protocolVersion = PcueRemoteClient.MinimumProtocolVersion,
                     version = AppUpdateService.InstalledVersion,
-                    commander = new
+                    machine = Environment.MachineName,
+                    updatedUtc = DateTime.UtcNow.ToString("o"),
+                    commander = new PcueCommanderStatus
                     {
                         connected = Corsair_Commander_Connected,
                         firmware = Commander_SN.Text,
                     },
-                    cpu = new
+                    cpu = new PcueCpuStatus
                     {
                         temperature = CPU_array.Length > 0 ? CPU_array[0].Text : null,
                         mhz = CPU_array.Length > 3 ? CPU_array[3].Text : null,
                         load = CPU_array.Length > 6 ? CPU_array[6].Text : null,
                         monitoring = CpuDataTimer.Enabled,
+                        temperatureStats = new PcueMetricStatus
+                        {
+                            current = latestCpuTemperature,
+                            min = stats.Min(StatCpuTemp),
+                            max = stats.Max(StatCpuTemp),
+                            average = stats.Average(StatCpuTemp),
+                        },
+                        mhzStats = new PcueMetricStatus
+                        {
+                            current = latestCpuClock,
+                            min = stats.Min(StatCpuClock),
+                            max = stats.Max(StatCpuClock),
+                            average = stats.Average(StatCpuClock),
+                        },
+                        loadStats = new PcueMetricStatus
+                        {
+                            current = latestCpuLoad,
+                            min = stats.Min(StatCpuLoad),
+                            max = stats.Max(StatCpuLoad),
+                            average = stats.Average(StatCpuLoad),
+                        },
                     },
-                    fans,
-                    tachometer = new
+                    fans = fans,
+                    tachometer = new PcueTachometerStatus
                     {
                         connected = bench_tach != null && bench_tach.IsConnected,
                         rpm = tachRpm,                      // null = stale or no signal
                         batteryLow = bench_tach != null && bench_tach.BatteryLow,
                         assignedFan = tachAssignedChannel >= 0 ? (int?)(tachAssignedChannel + 1) : null,
                     },
-                    hold = new
+                    hold = new PcueHoldStatus
                     {
                         running = rpmHold != null && rpmHold.IsRunning,
                         status = rpmHold != null ? rpmHold.Status.ToString() : FanHoldStatus.Idle.ToString(),
+                        display = Hold_Status_Label.Text,
                         fan = holdChannel >= 0 ? (int?)(holdChannel + 1) : null,
                         duty = holdDuty,                    // null when this session never set one
-                        dutySource,
+                        dutySource = dutySource,
                         target = (int)holdConfig.TargetRpm,
                         tachoAdjust = Tacho_Adjust_CheckBox.IsChecked == true,
+                    },
+                    settings = new PcueUiSettingsStatus
+                    {
+                        averageValues = AVG_values.IsChecked == true,
+                        autoStart = autostartCheckBox.IsChecked == true,
+                        autoConnect = Auto_Connect_CheckBox.IsChecked == true,
                     },
                 };
             }));
@@ -1158,6 +1322,38 @@ namespace pCUE
             if (!fanModeWriteOk[channel])
                 return "device rejected the mode change for fan " + fan + ".";
             return null;
+        }
+
+        public string ApplyFanSetpoints(int[] values)
+        {
+            if (values == null || values.Length != 6) return "values must contain exactly six setpoints.";
+            for (int i = 0; i < values.Length; i++)
+                if (values[i] < 0 || values[i] > 3500)
+                    return "fan " + (i + 1) + " setpoint must be 0-3500.";
+            if (!Corsair_Commander_Connected) return "Commander PRO is not connected.";
+
+            string result = null;
+            Dispatcher.Invoke(new Action(delegate
+            {
+                //Populate the six boxes without the local Sync checkbox rewriting each assignment
+                //from Fan #1. Restore Sync immediately; it remains a view/edit convenience.
+                bool sync = Sync_Fans_CheckBox.IsChecked == true;
+                Sync_Fans_CheckBox.IsChecked = false;
+                try
+                {
+                    for (int i = 0; i < 6; i++) Fan_Numeric_Boxes[i].Value = (uint)values[i];
+                }
+                finally { Sync_Fans_CheckBox.IsChecked = sync; }
+
+                StopRpmHold("remote batch setpoints");
+                var rejected = new List<string>();
+                for (int i = 0; i < 6; i++)
+                    if (!Set_Fan_Speed_Function_Commander_Pro(i)) rejected.Add("fan " + (i + 1));
+                if (rejected.Count > 0)
+                    result = "device rejected " + string.Join(", ", rejected) +
+                             " (fixed RPM needs a 4-pin/PWM channel).";
+            }));
+            return result;
         }
 
         public string StartHold(int fan, int rpm)
@@ -1365,6 +1561,406 @@ namespace pCUE
             return null;
         }
 
+        public string SetAverageValues(bool on)
+        {
+            Dispatcher.Invoke(new Action(delegate { AVG_values.IsChecked = on; }));
+            return null;
+        }
+
+        public string SetAutoStart(bool on)
+        {
+            Dispatcher.Invoke(new Action(delegate { autostartCheckBox.IsChecked = on; }));
+            return null;
+        }
+
+        public string SetAutoConnect(bool on)
+        {
+            Dispatcher.Invoke(new Action(delegate { Auto_Connect_CheckBox.IsChecked = on; }));
+            return null;
+        }
+
+        public string SetTachoAdjust(bool on)
+        {
+            Dispatcher.Invoke(new Action(delegate { Tacho_Adjust_CheckBox.IsChecked = on; }));
+            return null;
+        }
+
+        public string KillIcue()
+        {
+            Dispatcher.Invoke(new Action(delegate { Kill_iCUE_Function(); }));
+            return null;
+        }
+
+        #region In-app remote pCUE client
+        private void Target_Mode_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (Remote_Client_Host_Box == null || remoteClient == null) return; //XAML still loading
+            ApplyTargetModeUi();
+        }
+
+        private void SaveLocalUiState()
+        {
+            for (int i = 0; i < 6; i++)
+            {
+                savedLocalModes[i] = Fan_Mode_Controls[i].SelectedIndex;
+                savedLocalSetpoints[i] = Fan_Numeric_Boxes[i].Value;
+            }
+            savedLocalSync = Sync_Fans_CheckBox.IsChecked == true;
+            savedLocalAverage = AVG_values.IsChecked == true;
+            savedLocalAutoStart = autostartCheckBox.IsChecked == true;
+            savedLocalAutoConnect = Auto_Connect_CheckBox.IsChecked == true;
+            savedLocalTachoAdjust = Tacho_Adjust_CheckBox.IsChecked == true;
+            savedLocalCommanderConnected = Corsair_Commander_Connected;
+            savedLocalCpuMonitoring = CpuDataTimer.Enabled;
+            savedLocalTachConnected = bench_tach != null && bench_tach.IsConnected;
+            savedLocalRemoteEnabled = Remote_Enable_CheckBox.IsChecked == true;
+            savedLocalCommanderFirmware = Commander_SN.Text;
+            savedLocalHoldDisplay = Hold_Status_Label.Text;
+            savedLocalTachAssignment = Tach_Fan_Assign.SelectedIndex;
+            localUiStateSaved = true;
+        }
+
+        private void RestoreLocalUiState()
+        {
+            remoteSnapshotApplying = true;
+            try
+            {
+                if (localUiStateSaved)
+                {
+                    Sync_Fans_CheckBox.IsChecked = false;
+                    for (int i = 0; i < 6; i++)
+                    {
+                        Fan_Mode_Controls[i].SelectedIndex = savedLocalModes[i];
+                        Fan_Numeric_Boxes[i].Value = savedLocalSetpoints[i];
+                    }
+                    Sync_Fans_CheckBox.IsChecked = savedLocalSync;
+                    AVG_values.IsChecked = savedLocalAverage;
+                    autostartCheckBox.IsChecked = savedLocalAutoStart;
+                    Auto_Connect_CheckBox.IsChecked = savedLocalAutoConnect;
+                    Tacho_Adjust_CheckBox.IsChecked = savedLocalTachoAdjust;
+                    Tach_Fan_Assign.SelectedIndex = savedLocalTachAssignment;
+                }
+
+                for (int ch = 0; ch < 6; ch++)
+                {
+                    int current;
+                    lock (fanRpmLock) current = latestFanRpm[ch];
+                    Fan_array[ch * 3].Text = current.ToString();
+                    Fan_array[ch * 3 + 1].Text = FormatStat(StatFanBase + ch, stats.Min(StatFanBase + ch));
+                    Fan_array[ch * 3 + 2].Text = FormatStat(StatFanBase + ch, stats.Max(StatFanBase + ch));
+                }
+                Set_Fan_Average_Column();
+                CPU_array[0].Text = latestCpuTemperature.ToString("0.0");
+                CPU_array[3].Text = latestCpuClock.ToString("N1");
+                CPU_array[6].Text = latestCpuLoad.ToString("N1");
+                RenderCpuMinMaxColumns();
+                Commander_SN.Text = savedLocalCommanderFirmware ?? "";
+                Open_Corsair_Commander.Content = Corsair_Commander_Connected ? "Close" : "Open";
+                SetStatus(Corsair_Commander_Connected ? "● Connected" : "● Disconnected",
+                          Corsair_Commander_Connected ? System.Windows.Media.Brushes.Lime
+                                                     : System.Windows.Media.Brushes.Gainsboro);
+                bool localTachConnected = bench_tach != null && bench_tach.IsConnected;
+                Tach_Connect_Button.Content = localTachConnected ? "Disconnect" : "Connect Tach";
+                Tach_Status_Label.Text = localTachConnected ? "● Connected" : "● Disconnected";
+                Tach_Status_Label.Foreground = localTachConnected
+                    ? System.Windows.Media.Brushes.Lime : System.Windows.Media.Brushes.Gainsboro;
+                Tach_RPM_Readout.Text = "----";
+                Tach_Battery_Label.Visibility = Visibility.Collapsed;
+                Hold_Status_Label.Text = savedLocalHoldDisplay ?? "";
+
+                if (localUiStateSaved)
+                {
+                    if (savedLocalCpuMonitoring)
+                    {
+                        CpuDataTimer.Start();
+                        Start_CPU_data.Content = "Stop";
+                    }
+                    if (savedLocalCommanderConnected && !Corsair_Commander_Connected)
+                        Open_Corsair_Commander_Click(this, null);
+                    if (savedLocalTachConnected && bench_tach != null && !bench_tach.IsConnected)
+                    {
+                        try { bench_tach.Connect(); }
+                        catch (Exception ex) { AppLog.Warn("Could not restore the local tachometer: " + ex.Message); }
+                    }
+                }
+            }
+            finally { remoteSnapshotApplying = false; }
+        }
+
+        private void ApplyTargetModeUi()
+        {
+            bool remote = IsRemoteMode;
+            Remote_Client_Host_Box.IsEnabled = remote;
+            Remote_Client_Port_Box.IsEnabled = remote;
+            Remote_Client_Token_Box.IsEnabled = remote;
+            Remote_Client_Connect_Button.IsEnabled = remote;
+            Remote_Client_Discover_Button.IsEnabled = remote;
+
+            //A client-mode pCUE never proxies its selected target to a third instance. This keeps
+            //the server contract unambiguously local and prevents accidental control chains.
+            Remote_Enable_CheckBox.IsEnabled = !remote;
+            Remote_Port_Box.IsEnabled = !remote;
+            Remote_Token_Box.IsEnabled = !remote;
+
+            if (remote)
+            {
+                SaveLocalUiState();
+                if (Remote_Enable_CheckBox.IsChecked == true) Remote_Enable_CheckBox.IsChecked = false;
+                ApplyRemoteControlState();
+                CpuDataTimer.Stop();
+                Start_CPU_data.Content = "Start";
+                SetRemoteActionControlsEnabled(false);
+                Remote_Client_Status_Label.Text = "● Enter a remote pCUE host and connect";
+                Remote_Client_Status_Label.Foreground = UpdateAlertBrush;
+            }
+            else
+            {
+                remoteClient.Disconnect();
+                lastRemoteSnapshot = null;
+                Array.Clear(remoteSetpointDirty, 0, remoteSetpointDirty.Length);
+                this.Title = localWindowTitle;
+                Remote_Client_Connect_Button.Content = "Connect";
+                Remote_Client_Status_Label.Text = "● This PC";
+                Remote_Client_Status_Label.Foreground = UpdateInfoBrush;
+                SetRemoteActionControlsEnabled(true);
+                RestoreLocalUiState();
+                if (localUiStateSaved) Remote_Enable_CheckBox.IsChecked = savedLocalRemoteEnabled;
+            }
+        }
+
+        private void SetRemoteActionControlsEnabled(bool enabled)
+        {
+            Set_Fan_Speed.IsEnabled = enabled;
+            Open_Corsair_Commander.IsEnabled = enabled;
+            Start_CPU_data.IsEnabled = enabled;
+            Tach_Connect_Button.IsEnabled = enabled;
+            Tach_Fan_Assign.IsEnabled = enabled;
+            Reset_Button.IsEnabled = enabled;
+            Kill_iCUE_services.IsEnabled = enabled;
+            AVG_values.IsEnabled = enabled;
+            autostartCheckBox.IsEnabled = enabled;
+            Auto_Connect_CheckBox.IsEnabled = enabled;
+            Tacho_Adjust_CheckBox.IsEnabled = enabled;
+            foreach (ComboBox mode in Fan_Mode_Controls) mode.IsEnabled = enabled;
+        }
+
+        private async void Remote_Client_Connect_Click(object sender, RoutedEventArgs e)
+        {
+            if (!IsRemoteMode) return;
+            if (remoteClient.IsConnected)
+            {
+                remoteClient.Disconnect();
+                Remote_Client_Connect_Button.Content = "Connect";
+                Remote_Client_Status_Label.Text = "● Disconnected";
+                Remote_Client_Status_Label.Foreground = UpdateAlertBrush;
+                SetRemoteActionControlsEnabled(false);
+                return;
+            }
+
+            if (!int.TryParse(Remote_Client_Port_Box.Text.Trim(), out int port) || port < 1 || port > 65535)
+            {
+                SetRemoteClientError("Port must be 1-65535.");
+                return;
+            }
+
+            Remote_Client_Connect_Button.IsEnabled = false;
+            Remote_Client_Status_Label.Text = "● Connecting...";
+            Remote_Client_Status_Label.Foreground = UpdateInfoBrush;
+            try
+            {
+                SaveRemoteClientSettings();
+                await remoteClient.ConnectAsync(Remote_Client_Host_Box.Text,
+                                                port, Remote_Client_Token_Box.Password);
+                if (!IsRemoteMode) { remoteClient.Disconnect(); return; }
+                Remote_Client_Connect_Button.Content = "Disconnect";
+            }
+            catch (Exception ex) { SetRemoteClientError(ex.Message); }
+            finally { Remote_Client_Connect_Button.IsEnabled = IsRemoteMode; }
+        }
+
+        private async void Remote_Client_Discover_Click(object sender, RoutedEventArgs e)
+        {
+            if (!IsRemoteMode) return;
+            Remote_Client_Discover_Button.IsEnabled = false;
+            Remote_Client_Status_Label.Text = "● Looking for pCUE on the LAN...";
+            Remote_Client_Status_Label.Foreground = UpdateInfoBrush;
+            try
+            {
+                PcueDiscoveryResult found = await remoteClient.DiscoverAsync();
+                if (!IsRemoteMode) return;
+                if (found == null) { SetRemoteClientError("No pCUE instance answered discovery."); return; }
+                var uri = new Uri(found.url);
+                Remote_Client_Host_Box.Text = uri.Host;
+                Remote_Client_Port_Box.Text = uri.Port.ToString();
+                SaveRemoteClientSettings();
+                Remote_Client_Status_Label.Text = "● Found " + found.host + " (pCUE " + found.version + ")";
+                Remote_Client_Status_Label.Foreground = System.Windows.Media.Brushes.Lime;
+            }
+            catch (Exception ex) { SetRemoteClientError("Discovery failed: " + ex.Message); }
+            finally { Remote_Client_Discover_Button.IsEnabled = IsRemoteMode; }
+        }
+
+        private void Remote_Client_Settings_Changed(object sender, RoutedEventArgs e)
+        {
+            if (Remote_Client_Host_Box == null) return;
+            SaveRemoteClientSettings();
+        }
+
+        private void SaveRemoteClientSettings()
+        {
+            Properties.Settings.Default.Remote_Client_Host = Remote_Client_Host_Box.Text.Trim();
+            if (int.TryParse(Remote_Client_Port_Box.Text.Trim(), out int port) && port > 0 && port < 65536)
+                Properties.Settings.Default.Remote_Client_Port = port;
+            Properties.Settings.Default.Save();
+            //The client token is deliberately not persisted.
+        }
+
+        private void RemoteClient_SnapshotReceived(object sender, PcueStatusSnapshot snapshot)
+        {
+            try
+            {
+                Dispatcher.BeginInvoke(new Action(delegate
+                {
+                    if (IsRemoteMode) ApplyRemoteSnapshot(snapshot);
+                }));
+            }
+            catch (Exception ex) { AppLog.Warn("Remote snapshot dispatch failed: " + ex.Message); }
+        }
+
+        private void RemoteClient_ConnectionChanged(object sender, PcueRemoteConnectionEventArgs e)
+        {
+            try
+            {
+                Dispatcher.BeginInvoke(new Action(delegate
+                {
+                    if (!IsRemoteMode) return;
+                    Remote_Client_Status_Label.Text = "● " + e.Message;
+                    Remote_Client_Status_Label.Foreground = e.Connected
+                        ? System.Windows.Media.Brushes.Lime : UpdateAlertBrush;
+                    Remote_Client_Connect_Button.Content = e.Connected ? "Disconnect" : "Connect";
+                    SetRemoteActionControlsEnabled(e.Connected);
+                }));
+            }
+            catch (Exception ex) { AppLog.Warn("Remote connection dispatch failed: " + ex.Message); }
+        }
+
+        private void ApplyRemoteSnapshot(PcueStatusSnapshot snapshot)
+        {
+            if (snapshot == null || snapshot.commander == null || snapshot.cpu == null ||
+                snapshot.tachometer == null || snapshot.hold == null || snapshot.settings == null) return;
+
+            lastRemoteSnapshot = snapshot;
+            remoteSnapshotApplying = true;
+            try
+            {
+                this.Title = localWindowTitle + " — Remote: " + (snapshot.machine ?? remoteClient.Endpoint);
+                Remote_Client_Status_Label.Text = "● Connected to " + (snapshot.machine ?? remoteClient.Endpoint) +
+                                                  " — pCUE " + snapshot.version;
+                Remote_Client_Status_Label.Foreground = System.Windows.Media.Brushes.Lime;
+                SetRemoteActionControlsEnabled(true);
+
+                Commander_SN.Text = snapshot.commander.firmware ?? "";
+                Open_Corsair_Commander.Content = snapshot.commander.connected ? "Close" : "Open";
+                SetStatus(snapshot.commander.connected ? "● Connected" : "● Disconnected",
+                          snapshot.commander.connected ? System.Windows.Media.Brushes.Lime
+                                                       : System.Windows.Media.Brushes.Gainsboro);
+
+                AVG_values.IsChecked = snapshot.settings.averageValues;
+                CPU_box.Header = snapshot.settings.averageValues ? "CPU Current/AVG/Max" : "CPU Current/Min/Max";
+                autostartCheckBox.IsChecked = snapshot.settings.autoStart;
+                Auto_Connect_CheckBox.IsChecked = snapshot.settings.autoConnect;
+                Tacho_Adjust_CheckBox.IsChecked = snapshot.hold.tachoAdjust;
+                Start_CPU_data.Content = snapshot.cpu.monitoring ? "Stop" : "Start";
+                ApplyRemoteCpuMetric(snapshot.cpu.temperatureStats, 0, StatCpuTemp, snapshot.settings.averageValues);
+                ApplyRemoteCpuMetric(snapshot.cpu.mhzStats, 3, StatCpuClock, snapshot.settings.averageValues);
+                ApplyRemoteCpuMetric(snapshot.cpu.loadStats, 6, StatCpuLoad, snapshot.settings.averageValues);
+
+                foreach (PcueFanStatus fan in snapshot.fans)
+                {
+                    int ch = fan.fan - 1;
+                    if (ch < 0 || ch >= 6) continue;
+                    Fan_array[ch * 3].Text = fan.rpm.ToString();
+                    Fan_array[ch * 3 + 1].Text = Math.Round(fan.min).ToString();
+                    Fan_array[ch * 3 + 2].Text = Math.Round(fan.max).ToString();
+                    TextBox[] avg = { ed28, ed29, ed30, ed31, ed32, ed33 };
+                    avg[ch].Text = Math.Round(fan.average).ToString();
+                    Fan_Mode_Controls[ch].SelectedIndex = ModeIndex(fan.mode);
+                    if (!remoteSetpointDirty[ch]) Fan_Numeric_Boxes[ch].Value = (uint)Math.Max(0, fan.setpoint);
+                }
+
+                Tach_Connect_Button.Content = snapshot.tachometer.connected ? "Disconnect" : "Connect Tach";
+                Tach_Status_Label.Text = snapshot.tachometer.connected ? "● Connected" : "● Disconnected";
+                Tach_Status_Label.Foreground = snapshot.tachometer.connected
+                    ? System.Windows.Media.Brushes.Lime : System.Windows.Media.Brushes.Gainsboro;
+                Tach_RPM_Readout.Text = !snapshot.tachometer.connected ? "----"
+                    : snapshot.tachometer.rpm.HasValue ? Math.Round(snapshot.tachometer.rpm.Value).ToString()
+                    : "no signal";
+                Tach_RPM_Readout.Foreground = snapshot.tachometer.connected && !snapshot.tachometer.rpm.HasValue
+                    ? UpdateAlertBrush : UpdateInfoBrush;
+                Tach_Battery_Label.Visibility = snapshot.tachometer.batteryLow
+                    ? Visibility.Visible : Visibility.Collapsed;
+                Tach_Fan_Assign.SelectedIndex = snapshot.tachometer.assignedFan ?? 0;
+
+                Hold_Status_Label.Text = !string.IsNullOrWhiteSpace(snapshot.hold.display)
+                    ? snapshot.hold.display
+                    : snapshot.hold.status + (snapshot.hold.running
+                        ? "  target " + snapshot.hold.target + " RPM" +
+                          (snapshot.hold.duty.HasValue ? " @ " + snapshot.hold.duty.Value + "%" : "")
+                        : "");
+                Hold_Status_Label.Foreground = string.Equals(snapshot.hold.status, "Fault", StringComparison.OrdinalIgnoreCase)
+                    ? UpdateAlertBrush
+                    : string.Equals(snapshot.hold.status, "Stable", StringComparison.OrdinalIgnoreCase)
+                        ? System.Windows.Media.Brushes.Lime : UpdateInfoBrush;
+            }
+            finally { remoteSnapshotApplying = false; }
+        }
+
+        private void ApplyRemoteCpuMetric(PcueMetricStatus metric, int currentIndex, int series, bool average)
+        {
+            if (metric == null) return;
+            CPU_array[currentIndex].Text = FormatStat(series, metric.current);
+            CPU_array[currentIndex + 1].Text = average
+                ? metric.average.ToString("0.#") : FormatStat(series, metric.min);
+            CPU_array[currentIndex + 2].Text = FormatStat(series, metric.max);
+        }
+
+        private static int ModeIndex(string mode)
+        {
+            switch ((mode ?? "").Trim().ToLowerInvariant())
+            {
+                case "3pin": return 1;
+                case "4pin": return 2;
+                case "disconnect": return 3;
+                default: return 0;
+            }
+        }
+
+        private void SetRemoteClientError(string text)
+        {
+            if (!IsRemoteMode) return;
+            Remote_Client_Status_Label.Text = "● " + text;
+            Remote_Client_Status_Label.Foreground = UpdateAlertBrush;
+            SetRemoteActionControlsEnabled(false);
+        }
+
+        private void ShowRemoteActionResult(PcueApiActionResponse result, string successText = null)
+        {
+            if (!IsRemoteMode) return;
+            if (result == null || !result.ok)
+            {
+                Remote_Client_Status_Label.Text = "● " + (result?.error ?? "Remote pCUE did not return a result.");
+                Remote_Client_Status_Label.Foreground = UpdateAlertBrush;
+                SetRemoteActionControlsEnabled(remoteClient.IsConnected);
+                return;
+            }
+            if (!string.IsNullOrWhiteSpace(successText))
+            {
+                Remote_Client_Status_Label.Text = "● " + successText;
+                Remote_Client_Status_Label.Foreground = System.Windows.Media.Brushes.Lime;
+            }
+        }
+        #endregion
+
         //Command-line driven so nothing is persistently exposed and no token is ever written to disk:
         //   pCUE.exe --remote
         //   pCUE.exe --remote --remote-prefix=http://+:5056/ --remote-token=SECRET
@@ -1474,6 +2070,15 @@ namespace pCUE
         {
             if (Remote_Port_Box == null || Remote_Token_Box == null) return;   //still loading XAML
 
+            //The HTTP server always exposes this pCUE instance's local hardware. Client mode turns
+            //it off in ApplyTargetModeUi, and must not allow a late LostFocus event to restart it.
+            if (IsRemoteMode)
+            {
+                Remote_Enable_CheckBox.IsChecked = false;
+                ApplyRemoteControlState();
+                return;
+            }
+
             Properties.Settings.Default.Remote_Enabled = Remote_Enable_CheckBox.IsChecked == true;
             if (int.TryParse(Remote_Port_Box.Text.Trim(), out int port) && port > 0 && port < 65536)
                 Properties.Settings.Default.Remote_Port = port;
@@ -1496,8 +2101,16 @@ namespace pCUE
             }
         }
 
-        private void Auto_Connect_Changed(object sender, RoutedEventArgs e)
+        private async void Auto_Connect_Changed(object sender, RoutedEventArgs e)
         {
+            if (remoteSnapshotApplying) return;
+            if (IsRemoteMode)
+            {
+                if (!remoteClient.IsConnected) { SetRemoteClientError("Remote pCUE is not connected."); return; }
+                ShowRemoteActionResult(await remoteClient.SetAutoConnectAsync(Auto_Connect_CheckBox.IsChecked == true));
+                return;
+            }
+
             Properties.Settings.Default.Auto_Connect = Auto_Connect_CheckBox.IsChecked == true;
             Properties.Settings.Default.Save();
         }
@@ -1671,8 +2284,16 @@ namespace pCUE
 
         //Unticking hands the fan back to plain duty control; the fan keeps its current duty until
         //the next Set Speed, rather than jumping.
-        private void Tacho_Adjust_Changed(object sender, RoutedEventArgs e)
+        private async void Tacho_Adjust_Changed(object sender, RoutedEventArgs e)
         {
+            if (remoteSnapshotApplying) return;
+            if (IsRemoteMode)
+            {
+                if (!remoteClient.IsConnected) { SetRemoteClientError("Remote pCUE is not connected."); return; }
+                ShowRemoteActionResult(await remoteClient.SetTachoAdjustAsync(Tacho_Adjust_CheckBox.IsChecked == true));
+                return;
+            }
+
             Properties.Settings.Default.Tacho_Adjust = Tacho_Adjust_CheckBox.IsChecked == true;
             Properties.Settings.Default.Save();
 
@@ -1689,6 +2310,7 @@ namespace pCUE
             {
                 Dispatcher.BeginInvoke(new Action(delegate
                 {
+                    if (IsRemoteMode) return;
                     string text = s.Status + "  " + Math.Round(s.FilteredRpm) + " RPM @ " + s.Duty + "%";
                     if (!string.IsNullOrEmpty(s.Note)) text += "  (" + s.Note + ")";
                     SetHoldStatus(text, s.Status == FanHoldStatus.Fault ? UpdateAlertBrush
@@ -1845,8 +2467,17 @@ namespace pCUE
 
         #region Bench Tachometer (external USB-HID)
         //Connect / disconnect the external bench tachometer.
-        private void Tach_Connect_Button_Click(object sender, RoutedEventArgs e)
+        private async void Tach_Connect_Button_Click(object sender, RoutedEventArgs e)
         {
+            if (IsRemoteMode)
+            {
+                if (!remoteClient.IsConnected) { SetRemoteClientError("Remote pCUE is not connected."); return; }
+                bool connected = lastRemoteSnapshot?.tachometer?.connected == true;
+                ShowRemoteActionResult(await remoteClient.SetTachConnectedAsync(!connected),
+                                       connected ? "Remote tachometer disconnected" : "Remote tachometer connected");
+                return;
+            }
+
             if (bench_tach == null) return;
             try
             {
@@ -1864,10 +2495,17 @@ namespace pCUE
 
         //Choose which fan the tachometer feeds. Index 0 = None; 1..6 = Fan #1..#6.
         //Read from the sender so an early SelectionChanged (during XAML init) can't NRE on the field.
-        private void Tach_Fan_Assign_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private async void Tach_Fan_Assign_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             int sel = ((ComboBox)sender).SelectedIndex;
             tachAssignedChannel = (sel >= 1 && sel <= 6) ? (sel - 1) : -1;
+
+            if (remoteSnapshotApplying) return;
+            if (IsRemoteMode)
+            {
+                if (!remoteClient.IsConnected) { SetRemoteClientError("Remote pCUE is not connected."); return; }
+                ShowRemoteActionResult(await remoteClient.SetTachAssignmentAsync(sel));
+            }
         }
 
         //Refresh the tach panel from the SAME freshness rule the fan column uses (ReadRpm() returns
@@ -1939,6 +2577,7 @@ namespace pCUE
             {
                 Dispatcher.BeginInvoke(new Action(delegate
                 {
+                    if (IsRemoteMode) return;
                     Tach_Connect_Button.Content = connected ? "Disconnect" : "Connect Tach";
                     //Same wording and colours as the Commander PRO status line above.
                     Tach_Status_Label.Text = connected ? "● Connected" : "● Disconnected";
@@ -1973,8 +2612,16 @@ namespace pCUE
             key.Close();
         }
 
-        private void Autostart(object sender, RoutedEventArgs e)
+        private async void Autostart(object sender, RoutedEventArgs e)
         {
+            if (remoteSnapshotApplying) return;
+            if (IsRemoteMode)
+            {
+                if (!remoteClient.IsConnected) { SetRemoteClientError("Remote pCUE is not connected."); return; }
+                ShowRemoteActionResult(await remoteClient.SetAutoStartAsync(autostartCheckBox.IsChecked == true));
+                return;
+            }
+
             if (autostartCheckBox.IsChecked == true)
             {
                 this.Startup(true);
@@ -1989,8 +2636,17 @@ namespace pCUE
             }
         }
 
-        private void Start_CPU_data_Click(object sender, RoutedEventArgs e)
+        private async void Start_CPU_data_Click(object sender, RoutedEventArgs e)
         {
+            if (IsRemoteMode)
+            {
+                if (!remoteClient.IsConnected) { SetRemoteClientError("Remote pCUE is not connected."); return; }
+                bool monitoring = lastRemoteSnapshot?.cpu?.monitoring == true;
+                ShowRemoteActionResult(await remoteClient.SetCpuMonitoringAsync(!monitoring),
+                                       monitoring ? "Remote CPU monitoring stopped" : "Remote CPU monitoring started");
+                return;
+            }
+
             if (Start_CPU_data.Content.ToString() == "Start")
             {
                 try

--- a/pCUE/Properties/AssemblyInfo.cs
+++ b/pCUE/Properties/AssemblyInfo.cs
@@ -59,4 +59,4 @@ using System.Windows;
 // 1.3.8 -> 1.3.9 -> 1.4.0 -> 1.4.1 ... Keep it THREE components; the bump task will not
 // touch a four-part value.
 [assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.5.4")]
+[assembly: AssemblyFileVersion("1.5.5")]

--- a/pCUE/Properties/Settings.Designer.cs
+++ b/pCUE/Properties/Settings.Designer.cs
@@ -142,5 +142,29 @@ namespace pCUE.Properties {
                 this["Tacho_Adjust"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string Remote_Client_Host {
+            get {
+                return ((string)(this["Remote_Client_Host"]));
+            }
+            set {
+                this["Remote_Client_Host"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("5056")]
+        public int Remote_Client_Port {
+            get {
+                return ((int)(this["Remote_Client_Port"]));
+            }
+            set {
+                this["Remote_Client_Port"] = value;
+            }
+        }
     }
 }

--- a/pCUE/Properties/Settings.settings
+++ b/pCUE/Properties/Settings.settings
@@ -32,5 +32,11 @@
     <Setting Name="Tacho_Adjust" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="Remote_Client_Host" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="Remote_Client_Port" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">5056</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/pCUE/Remote/DiscoveryBeacon.cs
+++ b/pCUE/Remote/DiscoveryBeacon.cs
@@ -96,6 +96,7 @@ namespace pCUE
                     string json = new JavaScriptSerializer().Serialize(new
                     {
                         app = "pCUE",
+                        protocolVersion = PcueRemoteClient.MinimumProtocolVersion,
                         version = AppUpdateService.InstalledVersion,
                         host = Environment.MachineName,
                         url = "http://" + localIp + ":" + _apiPort + "/",

--- a/pCUE/Remote/PcueRemoteClient.cs
+++ b/pCUE/Remote/PcueRemoteClient.cs
@@ -1,0 +1,361 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Script.Serialization;
+
+namespace pCUE
+{
+    /// <summary>
+    /// In-process client for another pCUE instance. It consumes the same HTTP/SSE surface as the
+    /// CLI, but exposes typed snapshots and commands to the WPF window without spawning a shell or
+    /// depending on any companion program.
+    /// </summary>
+    public sealed class PcueRemoteClient : IDisposable
+    {
+        public const int MinimumProtocolVersion = 2;
+        private static readonly TimeSpan CommandTimeout = TimeSpan.FromSeconds(7);
+        private static readonly int[] ReconnectDelaysMs = { 1000, 2000, 5000, 10000 };
+
+        private readonly JavaScriptSerializer _serializer = new JavaScriptSerializer();
+        private readonly SemaphoreSlim _commandGate = new SemaphoreSlim(1, 1);
+        private HttpClient _http;
+        private CancellationTokenSource _lifetime;
+        private Task _streamWorker;
+        private Uri _baseUri;
+        private string _token = "";
+        private bool _disposed;
+
+        public event EventHandler<PcueStatusSnapshot> SnapshotReceived;
+        public event EventHandler<PcueRemoteConnectionEventArgs> ConnectionChanged;
+
+        public bool IsConnected { get; private set; }
+        public string Endpoint { get { return _baseUri == null ? "" : _baseUri.ToString().TrimEnd('/'); } }
+        public DateTime LastSnapshotUtc { get; private set; } = DateTime.MinValue;
+
+        public async Task<PcueStatusSnapshot> ConnectAsync(string host, int port, string token)
+        {
+            ThrowIfDisposed();
+            Disconnect();
+
+            _baseUri = BuildBaseUri(host, port);
+            _token = token ?? "";
+            _http = new HttpClient { BaseAddress = _baseUri, Timeout = Timeout.InfiniteTimeSpan };
+            _lifetime = new CancellationTokenSource();
+
+            PcueStatusSnapshot first;
+            try
+            {
+                first = await GetStatusAsync(_lifetime.Token).ConfigureAwait(false);
+                ValidateSnapshot(first);
+            }
+            catch
+            {
+                Disconnect();
+                throw;
+            }
+
+            SetConnected(true, "Connected to " + first.machine + " (pCUE " + first.version + ")");
+            Publish(first);
+            CancellationToken streamToken = _lifetime.Token;
+            _streamWorker = Task.Run(() => StreamWithReconnectAsync(streamToken));
+            return first;
+        }
+
+        public void Disconnect()
+        {
+            CancellationTokenSource lifetime = _lifetime;
+            HttpClient http = _http;
+            _lifetime = null;
+            _streamWorker = null;
+            _http = null;
+
+            try { lifetime?.Cancel(); } catch { }
+            try { http?.CancelPendingRequests(); } catch { }
+            try { http?.Dispose(); } catch { }
+            try { lifetime?.Dispose(); } catch { }
+
+            bool wasConnected = IsConnected;
+            IsConnected = false;
+            LastSnapshotUtc = DateTime.MinValue;
+            if (wasConnected) RaiseConnectionChanged(false, "Disconnected");
+        }
+
+        public Task<PcueApiActionResponse> SetFanModeAsync(int fan, string mode) =>
+            PostAsync("fan/mode?fan=" + fan + "&value=" + Uri.EscapeDataString(mode ?? ""), null);
+
+        public Task<PcueApiActionResponse> SetCommanderOpenAsync(bool open) =>
+            PostAsync(open ? "commander/open" : "commander/close", null);
+
+        public Task<PcueApiActionResponse> SetCpuMonitoringAsync(bool on) =>
+            PostAsync(on ? "cpu/start" : "cpu/stop", null);
+
+        public Task<PcueApiActionResponse> SetTachConnectedAsync(bool connected) =>
+            PostAsync(connected ? "tach/connect" : "tach/disconnect", null);
+
+        public Task<PcueApiActionResponse> SetTachAssignmentAsync(int fan) =>
+            PostAsync("tach/assign?fan=" + fan, null);
+
+        public Task<PcueApiActionResponse> StopHoldAsync() => PostAsync("hold/stop", null);
+        public Task<PcueApiActionResponse> ResetStatsAsync() => PostAsync("reset", null);
+        public Task<PcueApiActionResponse> KillIcueAsync() => PostAsync("system/kill-icue", null);
+
+        public Task<PcueApiActionResponse> SetAverageValuesAsync(bool on) =>
+            PostAsync("settings/average?value=" + (on ? "1" : "0"), null);
+
+        public Task<PcueApiActionResponse> SetAutoStartAsync(bool on) =>
+            PostAsync("settings/auto-start?value=" + (on ? "1" : "0"), null);
+
+        public Task<PcueApiActionResponse> SetAutoConnectAsync(bool on) =>
+            PostAsync("settings/auto-connect?value=" + (on ? "1" : "0"), null);
+
+        public Task<PcueApiActionResponse> SetTachoAdjustAsync(bool on) =>
+            PostAsync("settings/tacho-adjust?value=" + (on ? "1" : "0"), null);
+
+        public Task<PcueApiActionResponse> ApplyFanSetpointsAsync(IReadOnlyList<int> values)
+        {
+            if (values == null || values.Count != 6)
+                throw new ArgumentException("Exactly six fan setpoints are required.", nameof(values));
+            return PostAsync("fans/apply", new Dictionary<string, object>
+            {
+                ["values"] = values.ToArray(),
+            });
+        }
+
+        public async Task<PcueDiscoveryResult> DiscoverAsync(int timeoutMs = 1800)
+        {
+            ThrowIfDisposed();
+            using var udp = new UdpClient(0);
+            udp.EnableBroadcast = true;
+            byte[] probe = Encoding.UTF8.GetBytes("PCUE_DISCOVER");
+            await udp.SendAsync(probe, probe.Length,
+                new IPEndPoint(IPAddress.Broadcast, DiscoveryBeacon.DefaultPort)).ConfigureAwait(false);
+
+            Task<UdpReceiveResult> receive = udp.ReceiveAsync();
+            Task timeout = Task.Delay(Math.Max(250, timeoutMs));
+            Task completed = await Task.WhenAny(receive, timeout).ConfigureAwait(false);
+            if (completed != receive) return null;
+
+            string json = Encoding.UTF8.GetString(receive.Result.Buffer);
+            PcueDiscoveryResult result = _serializer.Deserialize<PcueDiscoveryResult>(json);
+            return result != null && string.Equals(result.app, "pCUE", StringComparison.OrdinalIgnoreCase)
+                ? result
+                : null;
+        }
+
+        private async Task StreamWithReconnectAsync(CancellationToken token)
+        {
+            int failures = 0;
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    await ConsumeStreamAsync(token).ConfigureAwait(false);
+                    if (!token.IsCancellationRequested) throw new IOException("Remote status stream ended.");
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested) { break; }
+                catch (Exception ex)
+                {
+                    if (token.IsCancellationRequested) break;
+                    IsConnected = false;
+                    RaiseConnectionChanged(false, "Connection lost: " + ex.Message);
+
+                    int delay = ReconnectDelaysMs[Math.Min(failures, ReconnectDelaysMs.Length - 1)];
+                    failures++;
+                    try { await Task.Delay(delay, token).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { break; }
+
+                    try
+                    {
+                        PcueStatusSnapshot recovered = await GetStatusAsync(token).ConfigureAwait(false);
+                        ValidateSnapshot(recovered);
+                        failures = 0;
+                        SetConnected(true, "Reconnected to " + recovered.machine);
+                        Publish(recovered);
+                    }
+                    catch (OperationCanceledException) when (token.IsCancellationRequested) { break; }
+                    catch { /* the loop retries with bounded backoff */ }
+                }
+            }
+        }
+
+        private async Task ConsumeStreamAsync(CancellationToken token)
+        {
+            using HttpRequestMessage request = CreateRequest(HttpMethod.Get, "stream?interval=500");
+            using HttpResponseMessage response = await _http
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+                throw await CreateHttpErrorAsync(response).ConfigureAwait(false);
+
+            using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            while (!token.IsCancellationRequested)
+            {
+                string line = await reader.ReadLineAsync().ConfigureAwait(false);
+                if (line == null) break;
+                if (!line.StartsWith("data: ", StringComparison.Ordinal)) continue;
+
+                PcueStatusSnapshot snapshot = _serializer.Deserialize<PcueStatusSnapshot>(line.Substring(6));
+                ValidateSnapshot(snapshot);
+                if (!IsConnected) SetConnected(true, "Connected");
+                Publish(snapshot);
+            }
+        }
+
+        private async Task<PcueStatusSnapshot> GetStatusAsync(CancellationToken outerToken)
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(outerToken);
+            timeout.CancelAfter(CommandTimeout);
+            using HttpRequestMessage request = CreateRequest(HttpMethod.Get, "status");
+            using HttpResponseMessage response = await _http.SendAsync(request, timeout.Token).ConfigureAwait(false);
+            string json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+                throw CreateHttpError(response.StatusCode, json);
+            return _serializer.Deserialize<PcueStatusSnapshot>(json);
+        }
+
+        private async Task<PcueApiActionResponse> PostAsync(string path, object body)
+        {
+            ThrowIfDisposed();
+            if (_http == null || _lifetime == null || !IsConnected)
+                return new PcueApiActionResponse { ok = false, error = "Remote pCUE is not connected." };
+
+            await _commandGate.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                using var timeout = CancellationTokenSource.CreateLinkedTokenSource(_lifetime.Token);
+                timeout.CancelAfter(CommandTimeout);
+                using HttpRequestMessage request = CreateRequest(HttpMethod.Post, path);
+                if (body != null)
+                {
+                    string json = _serializer.Serialize(body);
+                    request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+                }
+
+                using HttpResponseMessage response = await _http.SendAsync(request, timeout.Token).ConfigureAwait(false);
+                string text = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                PcueApiActionResponse result;
+                try { result = _serializer.Deserialize<PcueApiActionResponse>(text); }
+                catch { result = null; }
+                if (result == null) result = new PcueApiActionResponse();
+                if (!response.IsSuccessStatusCode)
+                {
+                    result.ok = false;
+                    if (string.IsNullOrWhiteSpace(result.error))
+                        result.error = "Remote pCUE returned HTTP " + (int)response.StatusCode + ".";
+                }
+                if (result.status != null) Publish(result.status);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                return new PcueApiActionResponse { ok = false, error = ex.Message };
+            }
+            finally { _commandGate.Release(); }
+        }
+
+        private HttpRequestMessage CreateRequest(HttpMethod method, string relative)
+        {
+            var request = new HttpRequestMessage(method, relative);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            if (!string.IsNullOrEmpty(_token)) request.Headers.Add("X-pCUE-Token", _token);
+            return request;
+        }
+
+        private static async Task<Exception> CreateHttpErrorAsync(HttpResponseMessage response)
+        {
+            string text = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return CreateHttpError(response.StatusCode, text);
+        }
+
+        private static Exception CreateHttpError(HttpStatusCode status, string body)
+        {
+            string detail = body;
+            try
+            {
+                var parsed = new JavaScriptSerializer().Deserialize<PcueApiActionResponse>(body);
+                if (!string.IsNullOrWhiteSpace(parsed?.error)) detail = parsed.error;
+            }
+            catch { }
+            if (status == HttpStatusCode.Unauthorized)
+                detail = "Authentication failed. Check the remote pCUE token.";
+            return new InvalidOperationException(detail ?? ("HTTP " + (int)status));
+        }
+
+        private static Uri BuildBaseUri(string host, int port)
+        {
+            string value = (host ?? "").Trim();
+            if (value.Length == 0) throw new ArgumentException("Enter the remote PC name or IP address.");
+            if (!value.Contains("://")) value = "http://" + value;
+            if (!Uri.TryCreate(value, UriKind.Absolute, out Uri parsed))
+                throw new ArgumentException("The remote PC address is not valid.");
+            if (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps)
+                throw new ArgumentException("The remote pCUE address must use HTTP or HTTPS.");
+            if (!string.IsNullOrEmpty(parsed.UserInfo) || !string.IsNullOrEmpty(parsed.Query) ||
+                !string.IsNullOrEmpty(parsed.Fragment))
+                throw new ArgumentException("Enter only a host name or pCUE base URL.");
+            if (port < 1 || port > 65535) throw new ArgumentException("Port must be 1-65535.");
+
+            var builder = new UriBuilder(parsed) { Port = port, Path = "/", Query = "", Fragment = "" };
+            return builder.Uri;
+        }
+
+        private static void ValidateSnapshot(PcueStatusSnapshot snapshot)
+        {
+            if (snapshot == null || !string.Equals(snapshot.app, "pCUE", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("The target did not identify itself as pCUE.");
+            if (snapshot.protocolVersion < MinimumProtocolVersion)
+                throw new InvalidOperationException("Remote pCUE is too old for GUI control. Update it first.");
+            if (snapshot.fans == null || snapshot.fans.Count != 6)
+                throw new InvalidOperationException("Remote pCUE returned an incomplete fan status.");
+        }
+
+        private void Publish(PcueStatusSnapshot snapshot)
+        {
+            LastSnapshotUtc = DateTime.UtcNow;
+            SnapshotReceived?.Invoke(this, snapshot);
+        }
+
+        private void SetConnected(bool connected, string message)
+        {
+            bool changed = IsConnected != connected;
+            IsConnected = connected;
+            if (changed || connected) RaiseConnectionChanged(connected, message);
+        }
+
+        private void RaiseConnectionChanged(bool connected, string message) =>
+            ConnectionChanged?.Invoke(this, new PcueRemoteConnectionEventArgs(connected, message));
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(PcueRemoteClient));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            Disconnect();
+            _commandGate.Dispose();
+        }
+    }
+
+    public sealed class PcueRemoteConnectionEventArgs : EventArgs
+    {
+        public PcueRemoteConnectionEventArgs(bool connected, string message)
+        {
+            Connected = connected;
+            Message = message ?? "";
+        }
+
+        public bool Connected { get; }
+        public string Message { get; }
+    }
+}

--- a/pCUE/Remote/PcueRemoteModels.cs
+++ b/pCUE/Remote/PcueRemoteModels.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+
+namespace pCUE
+{
+    /// <summary>
+    /// Stable, typed status contract shared by pCUE's built-in HTTP server and its in-app remote
+    /// client. Property names intentionally match the existing lower-case JSON API so old CLI
+    /// consumers keep working while newer pCUE clients can deserialize without dynamic objects.
+    /// </summary>
+    public sealed class PcueStatusSnapshot
+    {
+        public string app { get; set; }
+        public int protocolVersion { get; set; }
+        public string version { get; set; }
+        public string machine { get; set; }
+        public string updatedUtc { get; set; }
+        public PcueCommanderStatus commander { get; set; }
+        public PcueCpuStatus cpu { get; set; }
+        public List<PcueFanStatus> fans { get; set; }
+        public PcueTachometerStatus tachometer { get; set; }
+        public PcueHoldStatus hold { get; set; }
+        public PcueUiSettingsStatus settings { get; set; }
+    }
+
+    public sealed class PcueCommanderStatus
+    {
+        public bool connected { get; set; }
+        public string firmware { get; set; }
+    }
+
+    public sealed class PcueMetricStatus
+    {
+        public double current { get; set; }
+        public double min { get; set; }
+        public double max { get; set; }
+        public double average { get; set; }
+    }
+
+    public sealed class PcueCpuStatus
+    {
+        //These three strings are retained for compatibility with the existing CLI.
+        public string temperature { get; set; }
+        public string mhz { get; set; }
+        public string load { get; set; }
+        public bool monitoring { get; set; }
+        public PcueMetricStatus temperatureStats { get; set; }
+        public PcueMetricStatus mhzStats { get; set; }
+        public PcueMetricStatus loadStats { get; set; }
+    }
+
+    public sealed class PcueFanStatus
+    {
+        public int fan { get; set; }
+        public int rpm { get; set; }
+        public string mode { get; set; }
+        public int setpoint { get; set; }
+        public double min { get; set; }
+        public double max { get; set; }
+        public double average { get; set; }
+    }
+
+    public sealed class PcueTachometerStatus
+    {
+        public bool connected { get; set; }
+        public double? rpm { get; set; }
+        public bool batteryLow { get; set; }
+        public int? assignedFan { get; set; }
+    }
+
+    public sealed class PcueHoldStatus
+    {
+        public bool running { get; set; }
+        public string status { get; set; }
+        public string display { get; set; }
+        public int? fan { get; set; }
+        public int? duty { get; set; }
+        public string dutySource { get; set; }
+        public int target { get; set; }
+        public bool tachoAdjust { get; set; }
+    }
+
+    public sealed class PcueUiSettingsStatus
+    {
+        public bool averageValues { get; set; }
+        public bool autoStart { get; set; }
+        public bool autoConnect { get; set; }
+    }
+
+    public sealed class PcueApiActionResponse
+    {
+        public bool ok { get; set; }
+        public string error { get; set; }
+        public PcueStatusSnapshot status { get; set; }
+    }
+
+    public sealed class PcueDiscoveryResult
+    {
+        public string app { get; set; }
+        public int protocolVersion { get; set; }
+        public string version { get; set; }
+        public string host { get; set; }
+        public string url { get; set; }
+        public bool requiresToken { get; set; }
+    }
+}

--- a/pCUE/Remote/RemoteControlServer.cs
+++ b/pCUE/Remote/RemoteControlServer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -17,7 +18,7 @@ namespace pCUE
     public interface IRemoteControlTarget
     {
         /// <summary>Everything a caller might want to read, as a serializable object.</summary>
-        object GetStatus();
+        PcueStatusSnapshot GetStatus();
 
         /// <summary>Set fan power (0-100 %). Returns null on success, or an error message.</summary>
         string SetFanDuty(int fan, int duty);
@@ -27,6 +28,9 @@ namespace pCUE
 
         /// <summary>Set connection mode: auto | 3pin | 4pin | disconnect.</summary>
         string SetFanMode(int fan, string mode);
+
+        /// <summary>Apply the six setpoint boxes exactly as the GUI's Set Speed button does.</summary>
+        string ApplyFanSetpoints(int[] values);
 
         /// <summary>Start the software closed-loop RPM hold on a fan.</summary>
         string StartHold(int fan, int rpm);
@@ -48,6 +52,13 @@ namespace pCUE
 
         /// <summary>Reset the Min/Max/Avg statistics.</summary>
         string ResetStats();
+
+        /// <summary>Persistent/UI controls needed for a remote pCUE window to mirror the bench.</summary>
+        string SetAverageValues(bool on);
+        string SetAutoStart(bool on);
+        string SetAutoConnect(bool on);
+        string SetTachoAdjust(bool on);
+        string KillIcue();
 
         /// <summary>Current closed-loop tunables.</summary>
         object GetHoldConfig();
@@ -191,6 +202,10 @@ namespace pCUE
                             ReadInt(context, body, "fan", -1), ReadString(context, body, "value"))).ConfigureAwait(false);
                         return;
 
+                    case "/fans/apply":
+                        await Act(context, body => _target.ApplyFanSetpoints(ReadIntArray(body, "values"))).ConfigureAwait(false);
+                        return;
+
                     case "/hold/start":
                         await Act(context, body => _target.StartHold(
                             ReadInt(context, body, "fan", -1), ReadInt(context, body, "rpm", -1))).ConfigureAwait(false);
@@ -265,6 +280,30 @@ namespace pCUE
 
                     case "/reset":
                         await Act(context, body => _target.ResetStats()).ConfigureAwait(false);
+                        return;
+
+                    case "/settings/average":
+                        await Act(context, body => _target.SetAverageValues(
+                            ReadBool(context, body, "value", false))).ConfigureAwait(false);
+                        return;
+
+                    case "/settings/auto-start":
+                        await Act(context, body => _target.SetAutoStart(
+                            ReadBool(context, body, "value", false))).ConfigureAwait(false);
+                        return;
+
+                    case "/settings/auto-connect":
+                        await Act(context, body => _target.SetAutoConnect(
+                            ReadBool(context, body, "value", false))).ConfigureAwait(false);
+                        return;
+
+                    case "/settings/tacho-adjust":
+                        await Act(context, body => _target.SetTachoAdjust(
+                            ReadBool(context, body, "value", false))).ConfigureAwait(false);
+                        return;
+
+                    case "/system/kill-icue":
+                        await Act(context, body => _target.KillIcue()).ConfigureAwait(false);
                         return;
 
                     // ---- diagnostics -------------------------------------------------------
@@ -401,6 +440,7 @@ namespace pCUE
             return new
             {
                 app = "pCUE",
+                protocolVersion = PcueRemoteClient.MinimumProtocolVersion,
                 version = AppUpdateService.InstalledVersion,
                 endpoints = new[]
                 {
@@ -409,6 +449,7 @@ namespace pCUE
                     "POST /fan/duty?fan=1&value=60    - set fan power, 0-100 %",
                     "POST /fan/rpm?fan=1&value=800    - Commander fixed RPM (4-pin/PWM channels only)",
                     "POST /fan/mode?fan=1&value=3pin  - auto | 3pin | 4pin | disconnect",
+                    "POST /fans/apply                  - apply all six GUI setpoints in one operation",
                     "POST /hold/start?fan=1&rpm=800   - software closed-loop RPM hold",
                     "POST /hold/stop                  - stop the hold",
                     "POST /commander/open|close       - connect / disconnect the Commander PRO",
@@ -416,6 +457,8 @@ namespace pCUE
                     "POST /tach/connect|disconnect    - bench tachometer",
                     "POST /tach/assign?fan=2          - feed fan N's RPM from the tachometer (0 = none)",
                     "POST /reset                      - reset Min/Max/Avg statistics",
+                    "POST /settings/*                 - average, auto-start, auto-connect, tacho-adjust",
+                    "POST /system/kill-icue           - stop conflicting Corsair services",
                     "GET  /log?tail=200               - recent diagnostic log lines",
                     "GET  /log/level?value=debug      - read or set the log level",
                     "POST /log/clear                  - clear the in-memory log",
@@ -504,6 +547,32 @@ namespace pCUE
             if (body != null && body.TryGetValue(name, out object v) && v != null)
                 return Convert.ToString(v);
             return context.Request.QueryString[name] ?? "";
+        }
+
+        private static bool ReadBool(HttpListenerContext context, Dictionary<string, object> body,
+                                     string name, bool fallback)
+        {
+            string value = ReadString(context, body, name);
+            if (bool.TryParse(value, out bool parsed)) return parsed;
+            if (int.TryParse(value, out int number)) return number != 0;
+            return fallback;
+        }
+
+        private static int[] ReadIntArray(Dictionary<string, object> body, string name)
+        {
+            if (body == null || !body.TryGetValue(name, out object raw) || raw == null || raw is string)
+                return null;
+
+            var values = new List<int>();
+            if (raw is IEnumerable sequence)
+            {
+                foreach (object item in sequence)
+                {
+                    if (!int.TryParse(Convert.ToString(item), out int value)) return null;
+                    values.Add(value);
+                }
+            }
+            return values.ToArray();
         }
 
         private static async Task WriteJsonAsync(HttpListenerContext context, HttpStatusCode status, object payload)

--- a/pCUE/pCUE.csproj
+++ b/pCUE/pCUE.csproj
@@ -117,6 +117,8 @@
     <Compile Include="Control\FanRpmHoldController.cs" />
     <Compile Include="Diagnostics\AppLog.cs" />
     <Compile Include="Remote\DiscoveryBeacon.cs" />
+    <Compile Include="Remote\PcueRemoteClient.cs" />
+    <Compile Include="Remote\PcueRemoteModels.cs" />
     <Compile Include="Remote\RemoteControlServer.cs" />
     <Compile Include="Tachometer\HidTachometer.cs" />
     <Compile Include="Updates\AppUpdateService.cs" />

--- a/scripts/Invoke-LocalCI.ps1
+++ b/scripts/Invoke-LocalCI.ps1
@@ -8,13 +8,15 @@
 
   Stages:
     1. Debug build   - must produce no NEW warnings beyond the known baseline.
-    2. UI layout     - renders every window off-screen and fails on overlapping controls.
+    2. Remote API    - runs a loopback server/client integration test, including authentication,
+                       SSE snapshots, typed commands and protocol-version rejection.
+    3. UI layout     - renders every window off-screen and fails on overlapping controls.
                        This exists because overlaps kept shipping: BATT LOW sat on top of the
                        tachometer status, "RPM:" on the fan selector, the hold status on
                        "Auto connect", and the Commander "Status:" label on its own value. Each
                        was found by eye, and the battery one was invisible until the moment it
                        mattered. All are the same one-line mistake in absolute margins.
-    3. Release pack  - proves the installer still builds. Skipped with -NoPack, because it bumps
+    4. Release pack  - proves the installer still builds. Skipped with -NoPack, because it bumps
                        the version.
 
 .EXAMPLE
@@ -56,6 +58,20 @@ $msbuild = Get-MSBuild
 
 Step 'Build (Debug)' {
     & $msbuild (Join-Path $root 'pCUE\pCUE.csproj') /t:Rebuild /p:Configuration=Debug /v:minimal /nologo
+}
+
+Step 'Remote protocol integration' {
+    $testProject = Join-Path $root 'tests\RemoteProtocolTests\RemoteProtocolTests.csproj'
+    & $msbuild $testProject /t:Rebuild /p:Configuration=Debug /v:minimal /nologo
+    if ($LASTEXITCODE -ne 0) { return }
+    & (Join-Path $root 'tests\RemoteProtocolTests\bin\Debug\pCUE.RemoteProtocolTests.exe')
+    if ($LASTEXITCODE -ne 0) { return }
+
+    $cli = Join-Path $root 'tools\pcue-cli.ps1'
+    $tokens = $null
+    $parseErrors = $null
+    [void][System.Management.Automation.Language.Parser]::ParseFile($cli, [ref]$tokens, [ref]$parseErrors)
+    if ($parseErrors.Count -gt 0) { throw ($parseErrors | Out-String) }
 }
 
 Step 'UI layout' {

--- a/tests/RemoteProtocolTests/Program.cs
+++ b/tests/RemoteProtocolTests/Program.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using pCUE;
+
+namespace pCUE.RemoteProtocolTests
+{
+    internal static class Program
+    {
+        private const string Token = "integration-test-token";
+
+        private static int Main()
+        {
+            try
+            {
+                RunAsync().GetAwaiter().GetResult();
+                Console.WriteLine("Remote protocol integration tests passed.");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("Remote protocol integration tests FAILED: " + ex);
+                return 1;
+            }
+        }
+
+        private static async Task RunAsync()
+        {
+            int port = GetFreeTcpPort();
+            var target = new FakeTarget();
+            using var server = new RemoteControlServer(target, "http://127.0.0.1:" + port + "/", Token);
+            server.Start();
+
+            using (var invalid = new PcueRemoteClient())
+            {
+                await ThrowsAsync<InvalidOperationException>(
+                    () => invalid.ConnectAsync("127.0.0.1", port, "wrong-token"),
+                    "Authentication failed");
+            }
+
+            using (var client = new PcueRemoteClient())
+            {
+                int snapshots = 0;
+                using var streamed = new ManualResetEventSlim(false);
+                using var connectionLost = new ManualResetEventSlim(false);
+                using var reconnected = new ManualResetEventSlim(false);
+                bool connectedOnce = false;
+                client.SnapshotReceived += delegate
+                {
+                    if (Interlocked.Increment(ref snapshots) >= 2) streamed.Set();
+                };
+                client.ConnectionChanged += delegate(object sender, PcueRemoteConnectionEventArgs e)
+                {
+                    if (e.Connected)
+                    {
+                        if (connectionLost.IsSet) reconnected.Set();
+                        connectedOnce = true;
+                    }
+                    else if (connectedOnce) connectionLost.Set();
+                };
+
+                PcueStatusSnapshot status = await client.ConnectAsync("127.0.0.1", port, Token);
+                Assert(client.IsConnected, "client should be connected");
+                Assert(status.machine == "REMOTE-TEST", "machine name should round-trip");
+                Assert(status.protocolVersion == PcueRemoteClient.MinimumProtocolVersion,
+                       "protocol version should round-trip");
+                Assert(streamed.Wait(TimeSpan.FromSeconds(3)), "SSE should deliver a live snapshot");
+
+                await Ok(client.SetFanModeAsync(2, "3pin"));
+                Assert(target.FanMode == "2:3pin", "fan mode route");
+
+                int[] setpoints = { 11, 22, 33, 44, 55, 66 };
+                PcueApiActionResponse applied = await client.ApplyFanSetpointsAsync(setpoints);
+                Assert(applied.ok, "batch setpoints should succeed");
+                Assert(target.Setpoints.SequenceEqual(setpoints), "batch setpoints body");
+                Assert(applied.status != null && applied.status.fans.Count == 6,
+                       "actions should return a typed status snapshot");
+
+                await Ok(client.SetCommanderOpenAsync(true));
+                await Ok(client.SetCpuMonitoringAsync(true));
+                await Ok(client.SetTachConnectedAsync(true));
+                await Ok(client.SetTachAssignmentAsync(4));
+                await Ok(client.SetAverageValuesAsync(true));
+                await Ok(client.SetAutoStartAsync(true));
+                await Ok(client.SetAutoConnectAsync(true));
+                await Ok(client.SetTachoAdjustAsync(true));
+                await Ok(client.ResetStatsAsync());
+                await Ok(client.KillIcueAsync());
+
+                Assert(target.CommanderOpen, "Commander route");
+                Assert(target.CpuMonitoring, "CPU route");
+                Assert(target.TachConnected && target.TachAssignment == 4, "tach routes");
+                Assert(target.AverageValues && target.AutoStart && target.AutoConnect && target.TachoAdjust,
+                       "remote settings routes");
+                Assert(target.ResetCount == 1 && target.KillCount == 1, "reset and kill routes");
+
+                server.Stop();
+                Assert(connectionLost.Wait(TimeSpan.FromSeconds(4)), "stream loss should be detected");
+                server.Start();
+                Assert(reconnected.Wait(TimeSpan.FromSeconds(8)), "client should reconnect automatically");
+                Assert(client.IsConnected, "reconnect should restore connection state");
+
+                client.Disconnect();
+                Assert(!client.IsConnected, "disconnect should clear connection state");
+            }
+
+            target.ProtocolVersion = 1;
+            using (var oldClient = new PcueRemoteClient())
+            {
+                await ThrowsAsync<InvalidOperationException>(
+                    () => oldClient.ConnectAsync("127.0.0.1", port, Token),
+                    "too old");
+            }
+        }
+
+        private static async Task Ok(Task<PcueApiActionResponse> task)
+        {
+            PcueApiActionResponse result = await task;
+            Assert(result != null && result.ok, result?.error ?? "remote action returned no result");
+        }
+
+        private static async Task ThrowsAsync<T>(Func<Task> action, string messagePart) where T : Exception
+        {
+            try { await action(); }
+            catch (T ex)
+            {
+                Assert(ex.Message.IndexOf(messagePart, StringComparison.OrdinalIgnoreCase) >= 0,
+                       "exception should contain '" + messagePart + "' but was '" + ex.Message + "'");
+                return;
+            }
+            throw new InvalidOperationException("Expected " + typeof(T).Name + ".");
+        }
+
+        private static void Assert(bool condition, string message)
+        {
+            if (!condition) throw new InvalidOperationException("Assertion failed: " + message);
+        }
+
+        private static int GetFreeTcpPort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        private sealed class FakeTarget : IRemoteControlTarget
+        {
+            public int ProtocolVersion { get; set; } = PcueRemoteClient.MinimumProtocolVersion;
+            public string FanMode { get; private set; }
+            public int[] Setpoints { get; private set; } = new int[6];
+            public bool CommanderOpen { get; private set; }
+            public bool CpuMonitoring { get; private set; }
+            public bool TachConnected { get; private set; }
+            public int TachAssignment { get; private set; }
+            public bool AverageValues { get; private set; }
+            public bool AutoStart { get; private set; }
+            public bool AutoConnect { get; private set; }
+            public bool TachoAdjust { get; private set; }
+            public int ResetCount { get; private set; }
+            public int KillCount { get; private set; }
+
+            public PcueStatusSnapshot GetStatus()
+            {
+                return new PcueStatusSnapshot
+                {
+                    app = "pCUE",
+                    protocolVersion = ProtocolVersion,
+                    version = "9.9.9",
+                    machine = "REMOTE-TEST",
+                    updatedUtc = DateTime.UtcNow.ToString("o"),
+                    commander = new PcueCommanderStatus { connected = CommanderOpen, firmware = "0.9.212" },
+                    cpu = new PcueCpuStatus
+                    {
+                        temperature = "42.0",
+                        mhz = "5000",
+                        load = "12.0",
+                        monitoring = CpuMonitoring,
+                        temperatureStats = Metric(42),
+                        mhzStats = Metric(5000),
+                        loadStats = Metric(12),
+                    },
+                    fans = Enumerable.Range(1, 6).Select(i => new PcueFanStatus
+                    {
+                        fan = i,
+                        rpm = i * 100,
+                        mode = i == 2 ? "3pin" : "4pin",
+                        setpoint = Setpoints[i - 1],
+                        min = i * 90,
+                        max = i * 110,
+                        average = i * 100,
+                    }).ToList(),
+                    tachometer = new PcueTachometerStatus
+                    {
+                        connected = TachConnected,
+                        rpm = TachConnected ? (double?)1234 : null,
+                        batteryLow = false,
+                        assignedFan = TachAssignment == 0 ? (int?)null : TachAssignment,
+                    },
+                    hold = new PcueHoldStatus
+                    {
+                        running = false,
+                        status = "Idle",
+                        display = "",
+                        target = 0,
+                        tachoAdjust = TachoAdjust,
+                    },
+                    settings = new PcueUiSettingsStatus
+                    {
+                        averageValues = AverageValues,
+                        autoStart = AutoStart,
+                        autoConnect = AutoConnect,
+                    },
+                };
+            }
+
+            private static PcueMetricStatus Metric(double value) => new PcueMetricStatus
+            {
+                current = value,
+                min = value - 1,
+                max = value + 1,
+                average = value,
+            };
+
+            public string SetFanDuty(int fan, int duty) => null;
+            public string SetFanRpm(int fan, int rpm) => null;
+            public string SetFanMode(int fan, string mode) { FanMode = fan + ":" + mode; return null; }
+            public string ApplyFanSetpoints(int[] values) { Setpoints = values; return null; }
+            public string StartHold(int fan, int rpm) => null;
+            public string StopHold() => null;
+            public string SetCommanderOpen(bool open) { CommanderOpen = open; return null; }
+            public string SetCpuMonitoring(bool on) { CpuMonitoring = on; return null; }
+            public string SetTachConnected(bool connected) { TachConnected = connected; return null; }
+            public string SetTachAssignment(int fan) { TachAssignment = fan; return null; }
+            public string ResetStats() { ResetCount++; return null; }
+            public string SetAverageValues(bool on) { AverageValues = on; return null; }
+            public string SetAutoStart(bool on) { AutoStart = on; return null; }
+            public string SetAutoConnect(bool on) { AutoConnect = on; return null; }
+            public string SetTachoAdjust(bool on) { TachoAdjust = on; return null; }
+            public string KillIcue() { KillCount++; return null; }
+            public object GetHoldConfig() => new { };
+            public string SetHoldConfig(Func<string, double?> get) => null;
+            public byte[] CaptureScreenshot(string window) => null;
+        }
+    }
+}

--- a/tests/RemoteProtocolTests/RemoteProtocolTests.csproj
+++ b/tests/RemoteProtocolTests/RemoteProtocolTests.csproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{637B0C9A-2584-45D9-83E3-35ADBD96EA22}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>pCUE.RemoteProtocolTests</RootNamespace>
+    <AssemblyName>pCUE.RemoteProtocolTests</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <LangVersion>12.0</LangVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\pCUE\pCUE.csproj">
+      <Project>{BE3BB717-C408-4BF4-8C92-582D88219788}</Project>
+      <Name>pCUE</Name>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tools/pcue-cli.ps1
+++ b/tools/pcue-cli.ps1
@@ -9,7 +9,7 @@
 
   The app must be running with Remote ticked (bottom strip). Loopback needs no token; any other
   machine does. Put it in PCUE_TOKEN rather than typing it every time - this script deliberately
-  does NOT write it to disk, matching the app, which never persists it either.
+  does NOT write it to disk, matching pCUE's in-app remote client.
 
   Set PCUE_SERVER to point at a bench box by default. With neither that nor -Server, the CLI
   tries localhost first and then asks the LAN (UDP 5057) who is listening.
@@ -124,12 +124,22 @@ function Resolve-Base {
     Die 'No pCUE found. Start it and tick Remote (bottom strip), or pass -Server.' $EXIT_UNREACHABLE
 }
 
-function Invoke-Api([string]$Path, [string]$Method = 'Get') {
+function Invoke-Api([string]$Path, [string]$Method = 'Get', [object]$Body = $null) {
     $base = Resolve-Base
     $headers = @{}
     if ($Token) { $headers['X-pCUE-Token'] = $Token }
     try {
-        return Invoke-RestMethod -Uri "$base$Path" -Method $Method -Headers $headers -TimeoutSec $TimeoutSec
+        $request = @{
+            Uri = "$base$Path"
+            Method = $Method
+            Headers = $headers
+            TimeoutSec = $TimeoutSec
+        }
+        if ($null -ne $Body) {
+            $request.Body = $Body | ConvertTo-Json -Depth 6 -Compress
+            $request.ContentType = 'application/json'
+        }
+        return Invoke-RestMethod @request
     } catch {
         # Everything hinges on whether a response came back at all. PowerShell 7 fills in
         # ErrorDetails even when the connection was refused, so testing that first blames pCUE
@@ -249,6 +259,7 @@ pCUE CLI - every command
     duty <fan|all> <0-100>     set fan power %
     rpm  <fan> <rpm>           Commander fixed RPM (4-pin channels only)
     mode <fan> <auto|3pin|4pin|disconnect>
+    apply <v1> ... <v6>        apply the six GUI setpoint boxes together
     reset                      clear Min/Max/Avg statistics
 
   Closed-loop RPM hold
@@ -267,6 +278,11 @@ pCUE CLI - every command
     tach <connect|disconnect>
     assign <fan|none>          which fan the tachometer measures
     cpu <on|off>               CPU monitoring
+    average <on|off>           show running average instead of minimum
+    autostart <on|off>         launch pCUE with Windows
+    autoconnect <on|off>       connect hardware when pCUE starts
+    tach-adjust <on|off>       closed-loop tachometer adjustment
+    kill-icue                  stop the iCUE services
 
   Diagnostics
     log [lines]                recent log (default 100)
@@ -347,6 +363,21 @@ pCUE CLI - every command
         break
     }
 
+    'apply' {
+        Need 6 'apply <fan1> <fan2> <fan3> <fan4> <fan5> <fan6>'
+        if ($Rest.Count -ne 6) { Die 'apply requires exactly six setpoints.' $EXIT_USAGE }
+        $values = @()
+        foreach ($value in $Rest) {
+            $parsed = 0
+            if (-not [int]::TryParse($value, [ref]$parsed) -or $parsed -lt 0 -or $parsed -gt 3500) {
+                Die "Every setpoint must be 0-3500 (got '$value')." $EXIT_USAGE
+            }
+            $values += $parsed
+        }
+        Out-Result (Invoke-Api '/fans/apply' 'Post' @{ values = $values })
+        break
+    }
+
     'hold' {
         Need 2 'hold <fan> <rpm>'
         $fan = Get-FanArg $Rest[0]
@@ -400,6 +431,24 @@ pCUE CLI - every command
     }
 
     'reset' { Out-Result (Invoke-Api '/reset?x=1' 'Post'); break }
+
+    { $_ -in @('average', 'autostart', 'autoconnect', 'tach-adjust') } {
+        Need 1 "$Command <on|off>"
+        $value = $Rest[0].ToLowerInvariant()
+        if ($value -notin @('on', 'off')) { Die "$Command takes on or off." $EXIT_USAGE }
+        $path = @{
+            average = 'average'
+            autostart = 'auto-start'
+            autoconnect = 'auto-connect'
+            'tach-adjust' = 'tacho-adjust'
+        }[$Command.ToLowerInvariant()]
+        $number = 0
+        if ($value -eq 'on') { $number = 1 }
+        Out-Result (Invoke-Api "/settings/$path?value=$number" 'Post')
+        break
+    }
+
+    'kill-icue' { Out-Result (Invoke-Api '/system/kill-icue?x=1' 'Post'); break }
 
     # Spellings from the previous version of this script. Kept because bench scripts and the
     # handover notes already use them, and silently breaking those to tidy up a command list


### PR DESCRIPTION
Adds a Target selector so the full pCUE interface can control local hardware or another pCUE PC; typed protocol-v2 status, authenticated embedded HTTP/SSE client, LAN discovery, automatic reconnect, GUI-parity API/CLI routes, updated help, and loopback integration tests. Validation: full local CI passed; authentication, SSE, all new routes, server restart/reconnect, and old-protocol rejection passed; WPF layout measured 18 Help controls and 116 Main controls with zero overlaps; Release 1.5.5 installer and portable packages were built and SHA-256 verified. Installer SHA-256: 525392D64FF54DDC1A22D49C91646FE08CB49E81BFC8A6E3BA764BFC62A38B05